### PR TITLE
Add `create_meshtags` function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,8 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Output files
+*.xdmf
+*.h5
+*.bp

--- a/_toc.yml
+++ b/_toc.yml
@@ -9,6 +9,7 @@ parts:
     - file: "examples/real_function_space.py"
     - file: "examples/point_source.py"
     - file: "examples/xdmf_point_cloud.py"
+    - file: "examples/mark_entities.py"
   - caption: Reference
     chapters:
     - file: "docs/api.rst"

--- a/examples/mark_entities.py
+++ b/examples/mark_entities.py
@@ -1,0 +1,95 @@
+# # Entity markers
+#
+# Author: Jørgen S. Dokken
+#
+# SPDX-License-Identifier: MIT
+#
+# DOLFINx gives you full control for marking entities.
+# However, sometimes this can feel a bit repetative.
+# In this example we will show how to use :func:`scifem.mark_entities`
+
+from mpi4py import MPI
+import dolfinx
+import numpy as np
+
+# We start by creating a simple unit square
+
+mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 60, 60)
+
+# Next, we want to mark some of the cells in our domain.
+# We create three marker functions below.
+# Each of them takes in a ``(3, num_points)`` array, and returns a boolean array of size ``num_points``.
+
+def left(x):
+    return x[0] < 0.2
+
+def right(x):
+    return x[0] > 0.9
+
+def inner(x):
+    # We use numpy bit operator `&` for "and"
+    return (x[0] > 0.3) & (x[0] < 0.7)
+
+# We want to mark these entities with  with unique integers 1, 3 and 7.
+
+from scifem import create_meshtags
+
+cell_tag = create_meshtags(mesh, mesh.topology.dim, {1: left, 3:right, 7:inner})
+
+# Next we can plot these marked entities
+
+import pyvista
+pyvista.start_xvfb()
+
+vtk_grid = dolfinx.plot.vtk_mesh(mesh, cell_tag.dim, cell_tag.indices)
+
+grid = pyvista.UnstructuredGrid(*vtk_grid)
+grid.cell_data["Marker"] = cell_tag.values
+
+# Create plotter
+
+plotter = pyvista.Plotter()
+plotter.add_mesh(grid)
+plotter.view_xy()
+if not pyvista.OFF_SCREEN:
+    plotter.show()
+
+
+# We can also mark lower order entities, such as facets
+
+def circle(x):
+    return x[0]**2 + x[1]**2 <= 0.16**2
+
+def top(x):
+    return np.isclose(x[1], 1.0)
+
+
+facet_tags = create_meshtags(mesh, mesh.topology.dim-1, {2: top, 7:circle})
+
+
+facet_grid = dolfinx.plot.vtk_mesh(mesh, facet_tags.dim, facet_tags.indices)
+
+fgrid = pyvista.UnstructuredGrid(*facet_grid)
+fgrid.cell_data["Marker"] = facet_tags.values
+
+fplotter = pyvista.Plotter()
+fplotter.add_mesh(fgrid)
+fplotter.view_xy()
+if not pyvista.OFF_SCREEN:
+    fplotter.show()
+
+# We can also exclude all interior facets by adding `on_boundary=True`.
+
+boundary_facet_tags = create_meshtags(mesh, mesh.topology.dim-1, {2:top, 7: circle}, on_boundary=True)
+
+
+boundary_grid = dolfinx.plot.vtk_mesh(mesh, boundary_facet_tags.dim, boundary_facet_tags.indices)
+
+bfgrid = pyvista.UnstructuredGrid(*boundary_grid)
+bfgrid.cell_data["Marker"] = boundary_facet_tags.values
+
+bfplotter = pyvista.Plotter()
+bfplotter.add_mesh(bfgrid)
+bfplotter.view_xy()
+if not pyvista.OFF_SCREEN:
+    bfplotter.show()

--- a/src/scifem/__init__.py
+++ b/src/scifem/__init__.py
@@ -5,6 +5,9 @@ from . import _scifem  # type: ignore
 from .point_source import PointSource
 from .assembly import assemble_scalar
 from . import xdmf
+from .mesh import create_meshtags
+
+__all__ = ["PointSource", "assemble_scalar", "create_meshtags", "xdmf"]
 
 
 def create_real_functionspace(

--- a/src/scifem/mesh.py
+++ b/src/scifem/mesh.py
@@ -1,0 +1,53 @@
+import dolfinx
+import typing
+import numpy as np
+import numpy.typing as npt
+
+__all__ = ["create_meshtags"]
+
+
+def create_meshtags(
+    domain: dolfinx.mesh.Mesh,
+    dim: int,
+    entities_dict: dict[int, typing.Callable[[npt.NDArray[np.floating]], npt.NDArray[np.bool_]]],
+    on_boundary: bool = False,
+) -> dolfinx.mesh.MeshTags:
+    """Mark entities of specified dimension according to a geometrical marker function.
+
+    Args:
+        domain: A ``dolfinx.mesh.Mesh`` object
+        dim: Dimension of the entities to mark
+        entities_dict : A dictionary mapping integer tags with a geometrical marker function.
+            Example ``{tag: lambda x: x[0]<0}``
+        on_boundary: If ``True`` only locate entities on the boundary
+
+    Returns:
+        A ``dolfinx.mesh.MeshTags`` object with the corresponding entities marked.
+        If an entity satisfies multiple input marker functions,
+        it is not deterministic what value the entity gets.
+
+    Note:
+
+    """
+    # Create required connectivities
+    domain.topology.create_entities(dim)
+    domain.topology.create_connectivity(dim, 0)
+    domain.topology.create_connectivity(dim, domain.topology.dim)
+
+    # Create marker function
+    e_map = domain.topology.index_map(dim)
+    num_entities_local = e_map.size_local + e_map.num_ghosts
+    markers = np.full(num_entities_local, -1, dtype=np.int32)
+
+    if on_boundary:
+        locator = dolfinx.mesh.locate_entities_boundary
+    else:
+        locator = dolfinx.mesh.locate_entities
+
+    # Concatenate and sort the arrays based on indices
+    for tag, location in entities_dict.items():
+        entities = locator(domain, dim, location)
+        markers[entities] = tag
+
+    facets = np.flatnonzero(markers != -1).astype(np.int32)
+    return dolfinx.mesh.meshtags(domain, dim, facets, markers[facets])


### PR DESCRIPTION
Convenience function for creating meshtags based of python functions.

Based of what @bleyerj suggested in #26.

I've modified it slightly:
- added some notes on duplicate markers
- added `on_boundary` option.
-  type-hints

Added a demo to highlight how to use it and visualize meshtags with pyvista.