### PR TITLE
defer annotation evaluation

### DIFF
--- a/src/scifem/__init__.py
+++ b/src/scifem/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dolfinx
 import basix
 import numpy as np

--- a/src/scifem/assembly.py
+++ b/src/scifem/assembly.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from mpi4py import MPI
 import ufl
 import numpy as np

--- a/src/scifem/mesh.py
+++ b/src/scifem/mesh.py
@@ -9,10 +9,11 @@ __all__ = ["create_entity_markers"]
 
 
 # (tag, locator, on_boundary) where on_boundary is optional
-TaggedEntities = (
-    tuple[int, typing.Callable[[npt.NDArray[np.floating]], npt.NDArray[np.bool_]]]
-    | tuple[int, typing.Callable[[npt.NDArray[np.floating]], npt.NDArray[np.bool_]], bool]
-)
+if typing.TYPE_CHECKING:
+    TaggedEntities = (
+        tuple[int, typing.Callable[[npt.NDArray[np.floating]], npt.NDArray[np.bool_]]]
+        | tuple[int, typing.Callable[[npt.NDArray[np.floating]], npt.NDArray[np.bool_]], bool]
+    )
 
 
 def create_entity_markers(

--- a/src/scifem/mesh.py
+++ b/src/scifem/mesh.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dolfinx
 import typing
 import numpy as np

--- a/src/scifem/point_source.py
+++ b/src/scifem/point_source.py
@@ -2,6 +2,8 @@
 # Author: Jørgen S. Dokken
 # SPDX-License-Identifier: MIT
 
+from __future__ import annotations
+
 from .utils import unroll_dofmap
 from mpi4py import MPI
 from petsc4py import PETSc

--- a/src/scifem/solvers.py
+++ b/src/scifem/solvers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable
 import logging
 from packaging.version import parse as _v

--- a/src/scifem/utils.py
+++ b/src/scifem/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy.typing as npt
 import numpy as np
 

--- a/src/scifem/xdmf.py
+++ b/src/scifem/xdmf.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import typing
 import xml.etree.ElementTree as ET
 import contextlib


### PR DESCRIPTION
installing with Python 3.9 results in errors like

```
Traceback (most recent call last):
 │ │ │   File "/tmp/.tmpEaTl44/conda_build_script.py", line 1, in <module>
 │ │ │     import scifem
 │ │ │   File "$PREFIX/lib/python3.9/site-packages/scifem/__init__.py", line 6, in <module>
 │ │ │     from .point_source import PointSource
 │ │ │   File "$PREFIX/lib/python3.9/site-packages/scifem/point_source.py", line 18, in <module>
 │ │ │     class PointSource:
 │ │ │   File "$PREFIX/lib/python3.9/site-packages/scifem/point_source.py", line 24, in PointSource
 │ │ │     points: npt.NDArray[np.float32] | npt.NDArray[np.float64],
 │ │ │ TypeError: unsupported operand type(s) for |: 'types.GenericAlias' and 'types.GenericAlias'
```
adding:

```python
from __future__ import annotations
```

and making type definitions like `TaggedEntities` conditional on TYPE_CHECKING should allow building with Python 3.9

alternative is to require Python >=3.10, which is required for the PEP 604 `|` syntax.