### PR TITLE
increase tolerance in test_singular_poisson

### DIFF
--- a/tests/test_real_functionspace.py
+++ b/tests/test_real_functionspace.py
@@ -167,7 +167,7 @@ def test_singular_poisson(tensor, degree, dtype):
     error = dolfinx.fem.form(ufl.inner(u_ex - uh, u_ex - uh) * dx, dtype=dtype)
 
     e_local = dolfinx.fem.assemble_scalar(error)
-    tol = 8e3 * np.finfo(dtype).eps
+    tol = 1e4 * np.finfo(dtype).eps
     e_global = np.sqrt(mesh.comm.allreduce(e_local, op=MPI.SUM))
     assert np.isclose(e_global, 0, atol=tol)
 


### PR DESCRIPTION
conda builds seem to _just_ miss the 8e3 threshold on linux, and I see this was just increased to 8e3 in #24