### PR TITLE
Fix trame dependency in optional pyvista dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ repository = "https://github.com/scientificcomputing/scifem.git"
 [project.optional-dependencies]
 h5py = ["h5py"]
 adios2 = ["adios2"]
-docs = ["jupyter-book", "jupytext", "pyvista[all]", "sphinxcontrib-bibtex"]
+docs = ["jupyter-book", "jupytext", "pyvista[jupyter]", "sphinxcontrib-bibtex"]
 dev = ["ruff", "mypy", "bump-my-version", "pre-commit"]
 test = ["pytest", "petsc4py", "h5py"]
 all = ["scifem[docs,dev,test,audio2,h5py]"]


### PR DESCRIPTION
From our docs, it looks like `trame` is not installed
![Screenshot 2024-11-15 at 09 43 25](https://github.com/user-attachments/assets/d2e21e98-7134-4569-822c-09ce76747ae3)

By looking at [`pyvista's optional dependencies`](https://github.com/pyvista/pyvista/blob/d4ea1ca1e36d02d98ed211c06f9e60a5700a97ca/pyproject.toml#L37) it doesn't look like they have an optional dependency called `trame`. Changing this to just install everything, i,e `all`
