### PR TITLE
Be stricter with h5py mpi

### DIFF
--- a/src/scifem/xdmf.py
+++ b/src/scifem/xdmf.py
@@ -154,8 +154,9 @@ def h5pyfile(h5name, filemode="r", force_serial: bool = False, comm=None):
         h5file = h5py.File(h5name, filemode, driver="mpio", comm=comm)
     else:
         if comm.size > 1 and not force_serial:
-            warnings.warn(
-                "h5py is not installed with MPI support, while using {comm.size} processes"
+            raise ValueError(
+                "h5py is not installed with MPI support, while using {comm.size} processes.",
+                "If you really want to do this, turn on the `force_serial` flag.",
             )
         h5file = h5py.File(h5name, filemode)
     yield h5file

--- a/src/scifem/xdmf.py
+++ b/src/scifem/xdmf.py
@@ -155,7 +155,7 @@ def h5pyfile(h5name, filemode="r", force_serial: bool = False, comm=None):
     else:
         if comm.size > 1 and not force_serial:
             raise ValueError(
-                "h5py is not installed with MPI support, while using {comm.size} processes.",
+                f"h5py is not installed with MPI support, while using {comm.size} processes.",
                 "If you really want to do this, turn on the `force_serial` flag.",
             )
         h5file = h5py.File(h5name, filemode)


### PR DESCRIPTION
As this can cause all kinds of issues (ref @drew-parsons) I think if users do not explicitly want to force h5py serial on multiple ranks, we should throw an error.