### PR TITLE
Improve submesh wrappers

### DIFF
--- a/src/scifem.cpp
+++ b/src/scifem.cpp
@@ -261,8 +261,6 @@ transfer_meshtags_to_submesh(
 
   for (std::size_t i = 0; i < local_indices.size(); ++i)
   {
-    assert(i < parent_values.size());
-    assert(i < local_indices.size());
 
     auto parent_entity = local_indices[i];
     auto parent_value = parent_values[i];

--- a/src/scifem.cpp
+++ b/src/scifem.cpp
@@ -276,13 +276,9 @@ transfer_meshtags_to_submesh(
     {
       if (entity_found)
         break;
-      std::int32_t sub_cell = parent_entity_to_sub_cell[parent_cell];
-      if (sub_cell
-          > submesh_topology->index_map(submesh_tdim)->size_local()
-                + submesh_topology->index_map(submesh_tdim)->num_ghosts())
-      {
-      }
-      if (sub_cell > -1)
+
+      if (std::int32_t sub_cell = parent_entity_to_sub_cell[parent_cell];
+          sub_cell > -1)
       {
 
         // For a cell in the sub mesh find all attached entities,

--- a/src/scifem/mesh.py
+++ b/src/scifem/mesh.py
@@ -126,7 +126,7 @@ def reverse_mark_entities(
 
 
 def extract_submesh(
-    mesh: dolfinx.mesh.Mesh, entity_tag: dolfinx.mesh.MeshTags, tags: tuple[int, ...]
+    mesh: dolfinx.mesh.Mesh, entity_tag: dolfinx.mesh.MeshTags, tags: typing.Sequence[int, ...]
 ) -> tuple[
     dolfinx.mesh.Mesh,
     npt.NDArray[np.int32],

--- a/src/scifem/mesh.py
+++ b/src/scifem/mesh.py
@@ -103,3 +103,64 @@ def transfer_meshtags_to_submesh(
         entity_tag._cpp_object, submesh.topology._cpp_object, vertex_to_parent, cell_to_parent
     )
     return dolfinx.mesh.MeshTags(cpp_tag), sub_to_parent_entity_map
+
+
+def reverse_mark_entities(
+    entity_map: dolfinx.common.IndexMap, entities: npt.NDArray[np.int32]
+) -> npt.NDArray[np.int32]:
+    """Communicate entities marked on a single process to all processes that ghosts or
+    owns this entity.
+
+    Args:
+        entity_map: Index-map describing entity ownership
+        entities: Local indices of entities to communicate
+    Returns:
+        Local indices marked on any process sharing this entity
+    """
+    comm_vec = dolfinx.la.vector(entity_map, dtype=np.int32)
+    comm_vec.array[:] = 0
+    comm_vec.array[entities] = 1
+    comm_vec.scatter_reverse(dolfinx.la.InsertMode.add)
+    comm_vec.scatter_forward()
+    return np.flatnonzero(comm_vec.array).astype(np.int32)
+
+
+def extract_submesh(
+    mesh: dolfinx.mesh.Mesh, entity_tag: dolfinx.mesh.MeshTags, tags: tuple[int, ...]
+) -> tuple[
+    dolfinx.mesh.Mesh,
+    npt.NDArray[np.int32],
+    npt.NDArray[np.int32],
+    npt.NDArray[np.int32],
+    dolfinx.mesh.MeshTags,
+]:
+    """Generate a sub-mesh from a subset of tagged entities in a meshtag object.
+
+    Args:
+        mesh: The mesh to extract the submesh from.
+        entity_tag: MeshTags object containing marked entities.
+        tags: What tags the marked entities used in the submesh should have.
+
+    Returns:
+        A tuple `(submesh, subcell_to_parent_entity, subvertex_to_parent_vertex,
+        subnode_to_parent_node, entity_tag_on_submesh)`.
+    """
+
+    # Accumulate all entities, including ghosts, for the specfic set of tagged entities
+    edim = entity_tag.dim
+    mesh.topology.create_connectivity(edim, mesh.topology.dim)
+    emap = mesh.topology.index_map(entity_tag.dim)
+    marker = dolfinx.la.vector(emap)
+    tags_as_arr = np.asarray(tags, dtype=entity_tag.values.dtype)
+    all_tagged_indices = np.isin(entity_tag.values, tags_as_arr)
+    marker.array[entity_tag.indices[all_tagged_indices]] = 1
+    marker.scatter_reverse(dolfinx.la.InsertMode.add)
+    marker.scatter_forward()
+    entities = np.flatnonzero(marker.array)
+    # Extract submesh
+    submesh, cell_map, vertex_map, node_map = dolfinx.mesh.create_submesh(mesh, edim, entities)
+
+    # Transfer cell markers
+    new_et, _ = transfer_meshtags_to_submesh(entity_tag, submesh, vertex_map, cell_map)
+    new_et.name = entity_tag.name
+    return submesh, cell_map, vertex_map, node_map, new_et

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -109,9 +109,6 @@ def test_create_celltags_empty(entities_list):
     assert set(cell_tag.values) == set()
 
 
-import pytest
-
-
 @pytest.mark.parametrize("edim", [0, 1, 2, 3])
 def test_submesh_meshtags(edim):
     mesh = dolfinx.mesh.create_unit_cube(
@@ -127,13 +124,11 @@ def test_submesh_meshtags(edim):
     emap = mesh.topology.index_map(edim)
 
     # Put every second owned cell in submesh
-    num_cells_local = emap.size_local + emap.num_ghosts
-    subset_cells_local = np.arange(num_cells_local, dtype=np.int32)[::2]
-    cell_communicator = dolfinx.la.vector(emap, 1)
-    cell_communicator.array[subset_cells_local] = 1
-    cell_communicator.scatter_reverse(dolfinx.la.InsertMode.add)
-    cell_communicator.scatter_forward()
-    subset_cells = np.flatnonzero(cell_communicator.array).astype(np.int32)
+    num_entities_local = emap.size_local
+    subset_entities = np.arange(0, num_entities_local, 2, dtype=np.int32)
+    # Include ghosts entities
+    subset_cells = scifem.mesh.reverse_mark_entities(emap, subset_entities)
+
     submesh, entity_to_parent, vertex_to_parent, _ = dolfinx.mesh.create_submesh(
         mesh, edim, subset_cells
     )
@@ -153,14 +148,86 @@ def test_submesh_meshtags(edim):
             np.arange(num_parent_entities, dtype=np.int32),
             entity_communicator.array.astype(np.int32),
         )
-
         sub_tag, sub_entity_to_parent = scifem.mesh.transfer_meshtags_to_submesh(
             parent_tag, submesh, vertex_to_parent, entity_to_parent
         )
         submesh.topology.create_connectivity(i, edim)
-
         midpoints = dolfinx.mesh.compute_midpoints(submesh, i, sub_tag.indices)
         mesh.topology.create_connectivity(i, mesh.topology.dim)
         parent_midpoints = dolfinx.mesh.compute_midpoints(mesh, i, parent_tag.indices)
 
         np.testing.assert_allclose(midpoints, parent_midpoints[sub_entity_to_parent])
+
+
+@pytest.mark.parametrize("codim", [0, 1, 2])
+@pytest.mark.parametrize("tdim", [1, 2, 3])
+@pytest.mark.parametrize(
+    "ghost_mode", [dolfinx.mesh.GhostMode.none, dolfinx.mesh.GhostMode.shared_facet]
+)
+def test_submesh_creator(codim, tdim, ghost_mode):
+    edim = tdim - codim
+    if edim < 0:
+        pytest.xfail("Codim larger than tdim")
+
+    if tdim == 1:
+        mesh = dolfinx.mesh.create_unit_interval(MPI.COMM_WORLD, 27, ghost_mode=ghost_mode)
+    elif tdim == 2:
+        mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 10, 18, ghost_mode=ghost_mode)
+    elif tdim == 3:
+        mesh = dolfinx.mesh.create_unit_cube(MPI.COMM_WORLD, 7, 5, 8, ghost_mode=ghost_mode)
+    else:
+        raise ValueError("Invalid tdim")
+
+    tol = 50 * np.finfo(mesh.geometry.x.dtype).eps
+
+    def first_marker(x):
+        return x[0] <= 0.5 + tol
+
+    def second_marker(x):
+        return x[tdim - 1] >= 0.6 - tol
+
+    first_val = 2
+    second_val = 3
+    mesh.topology.create_entities(edim)
+    emap = mesh.topology.index_map(edim)
+
+    # Only include entities on this process to check if `extract_mesh` correctly accumulates them.
+    entities = np.arange(emap.size_local + emap.num_ghosts, dtype=np.int32)
+    values = np.full_like(entities, 1, dtype=np.int32)
+    values[dolfinx.mesh.locate_entities(mesh, edim, first_marker)] = first_val
+    values[dolfinx.mesh.locate_entities(mesh, edim, second_marker)] = second_val
+
+    # Constructor we are testing
+    etag = dolfinx.mesh.meshtags(mesh, edim, entities[: emap.size_local], values[: emap.size_local])
+    submesh, cell_map, vertex_map, node_map, sub_etag = scifem.mesh.extract_submesh(
+        mesh, etag, (first_val, second_val)
+    )
+
+    parent_indices = cell_map[sub_etag.indices]
+    np.testing.assert_allclose(sub_etag.values, values[parent_indices])
+
+    # Create with standard constructor (reference)
+    e_comm = dolfinx.la.vector(emap, 1)
+    e_comm.array[:] = 0
+    e_comm.array[dolfinx.mesh.locate_entities(mesh, edim, first_marker)] = 1
+    e_comm.array[dolfinx.mesh.locate_entities(mesh, edim, second_marker)] = 1
+    e_comm.scatter_reverse(dolfinx.la.InsertMode.add)
+    e_comm.scatter_forward()
+    sub_entities = np.flatnonzero(e_comm.array).astype(np.int32)
+    ref_submesh, ref_cm, ref_vm, ref_nm = dolfinx.mesh.create_submesh(mesh, edim, sub_entities)
+
+    np.testing.assert_allclose(cell_map, ref_cm)
+    np.testing.assert_allclose(vertex_map, ref_vm)
+    np.testing.assert_allclose(node_map, ref_nm)
+    assert (
+        submesh.topology.index_map(edim).size_local
+        == ref_submesh.topology.index_map(edim).size_local
+    )
+    assert (
+        submesh.topology.index_map(edim).size_global
+        == ref_submesh.topology.index_map(edim).size_global
+    )
+    assert (
+        submesh.topology.index_map(edim).num_ghosts
+        == ref_submesh.topology.index_map(edim).num_ghosts
+    )


### PR DESCRIPTION
Add convenience function for accumulating entity data across multiple processes.

Extend transfer_meshtags_to_submesh to include values from the meshtags ghosts (that were not included in the initial tag). Add submesh that given a cell tag and a set of markers creates the submesh, and transfers the data to the submesh. This constructor additionally automatically accumulates up ghosted indices.