### PR TITLE
Improve assemble scalar and add norm compilation

### DIFF
--- a/src/scifem/__init__.py
+++ b/src/scifem/__init__.py
@@ -6,7 +6,7 @@ import numpy as np
 import numpy.typing as npt
 from . import _scifem  # type: ignore
 from .point_source import PointSource
-from .assembly import assemble_scalar
+from .assembly import assemble_scalar, norm
 from . import xdmf
 from .solvers import BlockedNewtonSolver, NewtonSolver
 from .mesh import create_entity_markers, transfer_meshtags_to_submesh
@@ -27,6 +27,7 @@ __all__ = [
     "BlockedNewtonSolver",
     "transfer_meshtags_to_submesh",
     "evaluate_function",
+    "norm",
 ]
 
 

--- a/src/scifem/assembly.py
+++ b/src/scifem/assembly.py
@@ -4,19 +4,87 @@ from mpi4py import MPI
 import ufl
 import numpy as np
 import dolfinx
+from typing import Literal
+import numpy.typing as npt
+import typing
 
 
-def assemble_scalar(J: ufl.form.Form | dolfinx.fem.Form) -> np.floating | np.complexfloating:
+def _extract_dtype(expr: ufl.form.Form | ufl.core.expr.Expr | dolfinx.fem.Form) -> npt.DTypeLike:
+    """Given a ufl form, expression or a compiled DOLFINx form extract the data type that should
+    be used in form compilation.
+
+    Args:
+        form: The form to extract the data type from.
+
+    """
+    try:
+        return expr.dtype
+    except AttributeError:
+        try:
+            geom_type = ufl.domain.extract_domains(expr)[0].ufl_cargo().geometry.x.dtype
+        except AttributeError:
+            # Legacy support
+            geom_type = expr.ufl_domain().ufl_cargo().geometry.x.dtype
+        coefficients = expr.coefficients()
+        constants = expr.constants()
+        if (not coefficients) and (not constants):
+            return geom_type
+        else:
+            data_types: set[npt.DTypeLike] = set()
+            for coefficient in coefficients:
+                data_types.add(coefficient.dtype)
+            for constant in constants:
+                data_types.add(constant.dtype)
+
+            if len(data_types) > 1:
+                raise RuntimeError("All coefficients and constants must have the same data type")
+            assert len(data_types) == 1
+            return data_types.pop()
+
+
+def assemble_scalar(
+    J: ufl.form.Form | dolfinx.fem.Form,
+    entity_maps: typing.Optional[dict[dolfinx.mesh.Mesh, npt.NDArray[np.int32]]] = None,
+) -> np.floating | np.complexfloating:
     """Assemble a scalar form and gather result across processes
 
     Args:
         form: The form to assemble.
+        entity_maps: Maps of entities on related submeshes to the domain used in `J`.
 
     Returns:
         The accumulated value of the assembled form.
     """
-    compiled_form = dolfinx.fem.form(J)
+    dtype = _extract_dtype(J)
+    compiled_form = dolfinx.fem.form(J, entity_maps=entity_maps, dtype=dtype)
+
     if (rank := compiled_form.rank) != 0:
         raise ValueError(f"Form must be a scalar form, got for of arity {rank}")
     local_result = dolfinx.fem.assemble_scalar(compiled_form)
     return compiled_form.mesh.comm.allreduce(local_result, op=MPI.SUM)
+
+
+def norm(
+    expr: ufl.core.expr.Expr,
+    norm_type: Literal["L2", "H1", "H10"],
+    entity_maps: typing.Optional[dict[dolfinx.mesh.Mesh, npt.NDArray[np.int32]]] = None,
+) -> dolfinx.fem.Form:
+    """
+    Compile the norm of an UFL expression into a DOLFINx form.
+
+    Args:
+        expr: UFL expression
+        norm_type: Type of norm
+        entity_maps: Mapping for Constants and Coefficients within the expression that
+            lives on a submesh.
+    """
+    if norm_type == "L2":
+        form = ufl.inner(expr, expr) * ufl.dx
+    elif norm_type == "H1":
+        form = ufl.inner(expr, expr) * ufl.dx + ufl.inner(ufl.grad(expr), ufl.grad(expr)) * ufl.dx
+    elif norm_type == "H10":
+        form = ufl.inner(ufl.grad(expr), ufl.grad(expr)) * ufl.dx
+    else:
+        raise RuntimeError(f"Unexpected norm type: {norm_type}")
+    dtype = _extract_dtype(form)
+    return dolfinx.fem.form(form, entity_maps=entity_maps, dtype=dtype)

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -1,0 +1,102 @@
+from mpi4py import MPI
+
+from scifem import assemble_scalar, norm
+from dolfinx.mesh import create_unit_square
+from dolfinx.fem import Function, functionspace, Constant
+import ufl
+import pytest
+import numpy as np
+
+
+@pytest.mark.parametrize("gtype", [np.float64, np.float32])
+def test_assemble_scalar_spatial(gtype):
+    mesh = create_unit_square(MPI.COMM_WORLD, 3, 5, dtype=gtype)
+    x = ufl.SpatialCoordinate(mesh)
+    f = x[0] ** 2 * x[1] * ufl.dx
+    tol = 50 * np.finfo(gtype).eps
+    assert np.isclose(assemble_scalar(f), 1 / 3 * 1 / 2, atol=tol)
+
+
+@pytest.mark.parametrize(
+    "gtype, dtype",
+    [
+        [np.float64, np.float64],
+        [np.float64, np.complex128],
+        [np.float32, np.float32],
+        [np.float32, np.complex64],
+    ],
+)
+def test_assemble_scalar_constant(gtype, dtype):
+    mesh = create_unit_square(MPI.COMM_WORLD, 3, 5, dtype=gtype)
+    f = Constant(mesh, dtype(2.31))
+    tol = 50 * np.finfo(gtype).eps
+    assert np.isclose(assemble_scalar(f * ufl.dx), f.value, atol=tol)
+
+
+@pytest.mark.parametrize(
+    "gtype, dtype",
+    [
+        [np.float64, np.float64],
+        [np.float64, np.complex128],
+        [np.float32, np.float32],
+        [np.float32, np.complex64],
+    ],
+)
+def test_assemble_scalar_coefficient(gtype, dtype):
+    mesh = create_unit_square(MPI.COMM_WORLD, 5, 5, dtype=gtype)
+    V = functionspace(mesh, ("Lagrange", 3))
+    u = Function(V, dtype=dtype)
+    u.interpolate(lambda x: 3 * x[0] + 2 * x[1] ** 3)
+    tol = 50 * np.finfo(gtype).eps
+    assert np.isclose(assemble_scalar(u * ufl.dx), gtype(3 / 2 + 2 / 4), atol=tol)
+
+
+def test_incompatible_coeff_function():
+    mesh = create_unit_square(MPI.COMM_WORLD, 5, 5, dtype=np.float64)
+    V = functionspace(mesh, ("Lagrange", 3))
+    u = Function(V, dtype=np.float64)
+    u.interpolate(lambda x: 3 * x[0] + 2 * x[1] ** 3)
+    c = Constant(mesh, np.complex128(2.31))
+    with pytest.raises(
+        RuntimeError, match="All coefficients and constants must have the same data type"
+    ):
+        assemble_scalar(u * c * ufl.dx)
+
+
+@pytest.mark.parametrize(
+    "gtype, dtype",
+    [
+        [np.float64, np.float64],
+        [np.float64, np.complex128],
+        [np.float32, np.float32],
+        [np.float32, np.complex64],
+    ],
+)
+@pytest.mark.parametrize("norm_type", ["L2", "H1", "H10", "l2"])
+def test_norm(norm_type, dtype, gtype):
+    if norm_type == "l2":
+        pytest.xfail("Unexpected norm type")
+
+    mesh = create_unit_square(MPI.COMM_WORLD, 3, 5, dtype=gtype)
+    V = functionspace(mesh, ("Lagrange", 1))
+    u = Function(V, dtype=dtype)
+    u.interpolate(lambda x: x[0] ** 2 + x[1] ** 2)
+
+    x = ufl.SpatialCoordinate(mesh)
+    expr = u - ufl.sin(ufl.pi * x[0])
+    compiled_norm = norm(expr, norm_type)
+
+    result = assemble_scalar(compiled_norm)
+
+    if norm_type == "L2":
+        ref_form = ufl.inner(expr, expr) * ufl.dx
+    elif norm_type == "H1":
+        ref_form = (
+            ufl.inner(expr, expr) * ufl.dx + ufl.inner(ufl.grad(expr), ufl.grad(expr)) * ufl.dx
+        )
+    elif norm_type == "H10":
+        ref_form = ufl.inner(ufl.grad(expr), ufl.grad(expr)) * ufl.dx
+
+    reference = assemble_scalar(ref_form)
+    tol = 50 * np.finfo(dtype).eps
+    assert np.isclose(result, reference, atol=tol)


### PR DESCRIPTION
Assemble scalar:
- Get the correct data type for form compilation given a form (real, complex, single and double precision).
- Support entity maps (mixed domain support)

Norm:
Add convenience function for generating traditional norm expressions:
- L2, H1, H10.
- Supports entity maps.