### PR TITLE
Add convenience function to find 'exterior' facets of a subdomain and finding interface

### DIFF
--- a/src/scifem/mesh.py
+++ b/src/scifem/mesh.py
@@ -254,9 +254,17 @@ def compute_subdomain_exterior_facets(
     sub_facets = dolfinx.mesh.exterior_facet_indices(sub_mesh.topology)
 
     # Map exterior facet to (submesh_cell, local_facet_index) tuples
-    integration_entities = dolfinx.fem.compute_integration_domains(
-        dolfinx.fem.IntegralType.exterior_facet, sub_mesh.topology, sub_facets
-    )
+    try:
+        integration_entities = dolfinx.fem.compute_integration_domains(
+            dolfinx.fem.IntegralType.exterior_facet, sub_mesh.topology, sub_facets
+        )
+    except TypeError:
+        integration_entities = dolfinx.fem.compute_integration_domains(
+            dolfinx.fem.IntegralType.exterior_facet,
+            sub_mesh.topology,
+            sub_facets,
+            sub_mesh.topology.dim - 1,
+        )
     integration_entities = integration_entities.reshape(-1, 2)
     # Map submesh_cell to parent cell
     integration_entities[:, 0] = cell_map[integration_entities[:, 0]]

--- a/src/scifem/mesh.py
+++ b/src/scifem/mesh.py
@@ -14,6 +14,7 @@ __all__ = [
     "reverse_mark_entities",
     "extract_submesh",
     "find_interface",
+    "compute_subdomain_exterior_facets",
 ]
 
 


### PR DESCRIPTION
- `compute_subdomain_exterior_facets`: Give a subset of cells in the mesh, find the facets that connect to this subset of cells that are only connect to a single cell
- `find_interface`: Given a cell tag and a set of integers marking each subdomain `tags_0=(i_0, i_1, i_2), tags_1=(j_0, j_1,..)`, find the facets that are on the boundary between any tag in `tags_0` and `tags_1`.