### PR TITLE
Updated blocked solver API

### DIFF
--- a/examples/real_function_space.py
+++ b/examples/real_function_space.py
@@ -156,9 +156,9 @@ if main_assembly:
     b.axpy(1, b_real_space)
     b_real_space.destroy()
 else:
-    if dolfinx.__version__ == "0.8.0":
+    if Version(dolfinx.__version__) < Version("0.9.0"):
         maps = [(V.dofmap.index_map, V.dofmap.index_map_bs), (R.dofmap.index_map, R.dofmap.index_map_bs)]
-    elif Version(dolfinx.__version__) >= Version("0.9.0.0"):
+    else:
         maps = [(Wi.dofmap.index_map, Wi.dofmap.index_map_bs) for Wi in W.ufl_sub_spaces()]
 
     b_local = get_local_vectors(b, maps)

--- a/examples/real_function_space.py
+++ b/examples/real_function_space.py
@@ -200,7 +200,7 @@ else:
     x_local = get_local_vectors(xh, maps)
     uh.x.array[: len(x_local[0])] = x_local[0]
     uh.x.scatter_forward()
-
+xh.destroy()
 
 # We destroy all PETSc objects
 

--- a/examples/real_function_space.py
+++ b/examples/real_function_space.py
@@ -200,7 +200,6 @@ else:
     x_local = get_local_vectors(xh, maps)
     uh.x.array[: len(x_local[0])] = x_local[0]
     uh.x.scatter_forward()
-xh.destroy()
 
 # We destroy all PETSc objects
 

--- a/examples/real_function_space.py
+++ b/examples/real_function_space.py
@@ -219,7 +219,7 @@ vtk_mesh = dolfinx.plot.vtk_mesh(V)
 
 import pyvista
 
-#pyvista.start_xvfb(1.0)
+pyvista.start_xvfb(1.0)
 grid = pyvista.UnstructuredGrid(*vtk_mesh)
 grid.point_data["u"] = uh.x.array.real
 

--- a/examples/real_function_space.py
+++ b/examples/real_function_space.py
@@ -151,7 +151,7 @@ uh = dolfinx.fem.Function(V, name="u")
 if main_assembly:
     rh = dolfinx.fem.Function(R)
     rh.x.array[0] = h
-    b_real_space = b.copy()
+    b_real_space = b.duplicate()
     dolfinx.fem.petsc.assign([uh, rh], b_real_space)
     b.axpy(1, b_real_space)
 

--- a/examples/real_function_space.py
+++ b/examples/real_function_space.py
@@ -138,7 +138,7 @@ except AttributeError:
     dolfinx.fem.petsc.apply_lifting(b, a, bcs=bcs1)  # type: ignore
     b.ghostUpdate(PETSc.InsertMode.ADD, PETSc.ScatterMode.REVERSE)  # type: ignore
     bcs0 = dolfinx.fem.bcs_by_block(dolfinx.fem.extract_function_spaces(L), bcs)  # type: ignore
-    dolfinx.fem.petsc.set_bc(b, bcs0)  
+    dolfinx.fem.petsc.set_bc(b, bcs0)
     b.ghostUpdate(PETSc.InsertMode.INSERT, PETSc.ScatterMode.FORWARD)
 
 # Next, we modify the second part of the block to contain `h`

--- a/examples/real_function_space.py
+++ b/examples/real_function_space.py
@@ -216,7 +216,7 @@ vtk_mesh = dolfinx.plot.vtk_mesh(V)
 
 import pyvista
 
-#pyvista.start_xvfb()
+pyvista.start_xvfb(1.0)
 grid = pyvista.UnstructuredGrid(*vtk_mesh)
 grid.point_data["u"] = uh.x.array.real
 

--- a/examples/real_function_space.py
+++ b/examples/real_function_space.py
@@ -154,7 +154,7 @@ if main_assembly:
     b_real_space = b.duplicate()
     dolfinx.fem.petsc.assign([uh, rh], b_real_space)
     b.axpy(1, b_real_space)
-
+    b_real_space.destroy()
 else:
     if dolfinx.__version__ == "0.8.0":
         maps = [(V.dofmap.index_map, V.dofmap.index_map_bs), (R.dofmap.index_map, R.dofmap.index_map_bs)]
@@ -197,6 +197,13 @@ else:
     uh.x.array[: len(x_local[0])] = x_local[0]
     uh.x.scatter_forward()
 
+
+# We destroy all PETSc objects
+
+b.destroy()
+xh.destroy()
+A.destroy()
+ksp.destroy()
 
 diff = uh - u_exact(x)
 error = dolfinx.fem.form(ufl.inner(diff, diff) * ufl.dx)

--- a/examples/real_function_space.py
+++ b/examples/real_function_space.py
@@ -186,7 +186,7 @@ pc.setFactorSolverType("mumps")
 if main_assembly:
     xh = b.duplicate()
 else:
-    xh = dolfinx.fem.petsc.create_vector_block(L)
+    xh = dolfinx.fem.petsc.create_vector_block(L_compiled)
 
 ksp.solve(b, xh)
 xh.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = ["ruff", "mypy", "bump-my-version", "pre-commit"]
 test = ["pytest", "petsc4py", "h5py", "scifem[biomed]"]
 biomed = ["nibabel"]
 all = ["scifem[docs,dev,test,audio2,h5py,biomed]"]
+petsc = ["petsc4py"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/scifem/petsc.py
+++ b/src/scifem/petsc.py
@@ -1,0 +1,106 @@
+import dolfinx
+import typing
+
+__all__ = [
+    "zero_petsc_vector",
+    "ghost_update",
+    "apply_lifting_and_set_bc",
+]
+
+try:
+    from petsc4py import PETSc
+
+    def zero_petsc_vector(b):
+        """Zero a PETSc vector, including ghosts"""
+
+        if b.getType() == PETSc.Vec.Type.NEST:
+            for b_sub in b.getNestSubVecs():
+                with b_sub.localForm() as b_local:
+                    b_local.set(0.0)
+        else:
+            with b.localForm() as b_loc:
+                b_loc.set(0)
+
+    def ghost_update(x, insert_mode, scatter_mode):
+        """Ghost update a vector"""
+        if x.getType() == PETSc.Vec.Type.NEST:
+            for x_sub in x.getNestSubVecs():
+                x_sub.ghostUpdate(addv=insert_mode, mode=scatter_mode)
+        else:
+            x.ghostUpdate(addv=insert_mode, mode=scatter_mode)
+
+except ImportError:
+
+    def zero_petsc_vector(_b):
+        """Zero a PETSc vector, including ghosts"""
+        raise RuntimeError("petsc4py is not available. Cannot zero vector.")
+
+    def ghost_update(_x, _insert_mode, _scatter_mode):
+        """Ghost update a vector"""
+        raise RuntimeError("petsc4py is not available. Cannot ghost update vector.")
+
+
+if dolfinx.has_petsc4py:
+    from petsc4py import PETSc
+    import dolfinx.fem.petsc
+
+    def apply_lifting_and_set_bc(
+        b: PETSc.Vec,
+        a: typing.Union[
+            typing.Iterable[dolfinx.fem.Form], typing.Iterable[typing.Iterable[dolfinx.fem.Form]]
+        ],
+        bcs: typing.Union[
+            typing.Iterable[dolfinx.fem.DirichletBC],
+            typing.Iterable[typing.Iterable[dolfinx.fem.DirichletBC]],
+        ],
+        x: typing.Optional[PETSc.Vec] = None,
+        alpha: float = 1.0,
+    ):
+        """Apply lifting to a vector and set boundary conditions.
+
+        Convenience function to apply lifting and set boundary conditions for multiple matrix types.
+        This modifies the vector b such that
+
+        .. math::
+            b_{free} = b - alpha a[i] (u_bc[i] - x[i])
+            b_{bc} = u_bc[i]
+
+        where :math:`b_{free}` is the free part of the vector, :math:`b_{bc}` is the part that has
+        boundary conditions applied.
+
+        Args:
+            b: The vector to apply lifting to.
+            a: Sequence fo forms to apply lifting from. If the system is blocked or nested,
+                his is a nested list of forms.
+            bcs: The boundary conditions to apply. If the form is blocked or nested, this is a list,
+                while if it is a single form, this is a nested list.
+            x: Vector to subtract from the boundary conditions. Usually used in a Newton iteration.
+            alpha: The scaling factor for the boundary conditions.
+        """
+        if hasattr(dolfinx.fem.petsc, "create_vector_nest"):
+            raise NotImplementedError(
+                "This function is only implemented for later versions of DOLFINx."
+            )
+
+        try:
+            bcs0 = dolfinx.fem.bcs_by_block(dolfinx.fem.extract_function_spaces(a, 0), bcs)
+            bcs1 = dolfinx.fem.bcs_by_block(dolfinx.fem.extract_function_spaces(a, 1), bcs)
+        except AssertionError:
+            bcs0 = bcs
+            bcs1 = bcs
+
+        dolfinx.fem.petsc.apply_lifting(b, a, bcs=bcs1, x0=x, alpha=alpha)
+        ghost_update(b, PETSc.InsertMode.ADD_VALUES, PETSc.ScatterMode.REVERSE)
+        try:
+            dolfinx.fem.petsc.set_bc(b, bcs0, x0=x, alpha=alpha)
+        except AttributeError:
+            for _bcs in bcs0:
+                dolfinx.fem.petsc.set_bc(b, _bcs, x0=x, alpha=alpha)
+        ghost_update(b, PETSc.InsertMode.INSERT_VALUES, PETSc.ScatterMode.FORWARD)
+
+else:
+
+    def apply_lifting_and_set_bc(_b, _a, _bcs, _x, _alpha):
+        raise RuntimeError(
+            "petsc4py is not available. Cannot apply lifting and set boundary conditions."
+        )

--- a/src/scifem/petsc.py
+++ b/src/scifem/petsc.py
@@ -100,7 +100,7 @@ if dolfinx.has_petsc4py:
 
 else:
 
-    def apply_lifting_and_set_bc(_b, _a, _bcs, _x, _alpha):
+    def apply_lifting_and_set_bc(_b, _a, _bcs, _x, _alpha):  # type: ignore
         raise RuntimeError(
             "petsc4py is not available. Cannot apply lifting and set boundary conditions."
         )

--- a/src/scifem/solvers.py
+++ b/src/scifem/solvers.py
@@ -5,518 +5,545 @@ import logging
 from packaging.version import parse as _v
 
 import numpy as np
-from petsc4py import PETSc
 import ufl
 import dolfinx
 
-
 __all__ = ["NewtonSolver", "BlockedNewtonSolver"]
 
-logger = logging.getLogger(__name__)
+if not dolfinx.has_petsc4py or dolfinx.has_petsc:
 
-# assemble_vector_block(scale=...) is renamed assemble_vector_block(alpha=...)
-# in 0.9
-_alpha_kw: str = "alpha"
-if _v(dolfinx.__version__) < _v("0.9"):
-    _alpha_kw = "scale"
+    class NewtonSolver:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                "NewtonSolver is not available in this version of DOLFINx. "
+                "Please install a version of DOLFINx with PETSc4py support."
+            )
 
+    class BlockedNewtonSolver:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                "BlockedNewtonSolver is not available in this version of DOLFINx. "
+                "Please install a version of DOLFINx with PETSc4py support."
+            )
+else:
+    logger = logging.getLogger(__name__)
+    from petsc4py import PETSc
+    import dolfinx.fem.petsc
 
-class NewtonSolver:
-    max_iterations: int
-    _bcs: list[dolfinx.fem.DirichletBC]
-    A: PETSc.Mat
-    b: PETSc.Vec
-    _J: dolfinx.fem.Form | ufl.form.Form
-    _F: dolfinx.fem.Form | ufl.form.Form
-    _dx: PETSc.Vec
-    _error_on_convergence: bool
-    _pre_solve_callback: Callable[["NewtonSolver"], None] | None
-    _post_solve_callback: Callable[["NewtonSolver"], None] | None
+    # assemble_vector_block(scale=...) is renamed assemble_vector_block(alpha=...)
+    # in 0.9
+    _alpha_kw: str = "alpha"
+    if _v(dolfinx.__version__) < _v("0.9"):
+        _alpha_kw = "scale"
 
-    def __init__(
-        self,
-        F: list[dolfinx.fem.Form],
-        J: list[list[dolfinx.fem.Form]],
-        w: list[dolfinx.fem.Function],
-        bcs: list[dolfinx.fem.DirichletBC] | None = None,
-        max_iterations: int = 5,
-        petsc_options: dict[str, str | float | int | None] | None = None,
-        error_on_nonconvergence: bool = True,
-    ):
-        """
-        Create a Newton solver for a block nonlinear problem ``F(u) = 0``.
-        Solved as ``J(u) du = -F(u)``, where ``J`` is the Jacobian of ``F``.
+    class NewtonSolver:
+        max_iterations: int
+        _bcs: list[dolfinx.fem.DirichletBC]
+        A: PETSc.Mat
+        b: PETSc.Vec
+        _J: dolfinx.fem.Form | ufl.form.Form
+        _F: dolfinx.fem.Form | ufl.form.Form
+        _dx: PETSc.Vec
+        _error_on_convergence: bool
+        _pre_solve_callback: Callable[["NewtonSolver"], None] | None
+        _post_solve_callback: Callable[["NewtonSolver"], None] | None
 
-        Args:
-            F: List of forms defining the residual
-            J: List of lists of forms defining the Jacobian
-            w: List of functions representing the solution
-            bcs: List of Dirichlet boundary conditions
-            max_iterations: Maximum number of iterations in Newton solver
-            petsc_options: PETSc options for Krylov subspace solver.
-            error_on_nonconvergence: Raise an error if the linear solver
-                does not converge or Newton solver doesn't converge
-        """
-        # Compile forms if not compiled. Will throw error it requires entity maps
-        self._F = dolfinx.fem.form(F)
-        self._J = dolfinx.fem.form(J)
+        def __init__(
+            self,
+            F: list[dolfinx.fem.Form],
+            J: list[list[dolfinx.fem.Form]],
+            w: list[dolfinx.fem.Function],
+            bcs: list[dolfinx.fem.DirichletBC] | None = None,
+            max_iterations: int = 5,
+            petsc_options: dict[str, str | float | int | None] | None = None,
+            error_on_nonconvergence: bool = True,
+        ):
+            """
+            Create a Newton solver for a block nonlinear problem ``F(u) = 0``.
+            Solved as ``J(u) du = -F(u)``, where ``J`` is the Jacobian of ``F``.
 
-        # Store solution and accessible/modifiable properties
-        self._pre_solve_callback = None
-        self._post_solve_callback = None
-        self.max_iterations = max_iterations
-        self._error_on_convergence = error_on_nonconvergence
-        self.bcs = [] if bcs is None else bcs
-        self.w = w
+            Args:
+                F: List of forms defining the residual
+                J: List of lists of forms defining the Jacobian
+                w: List of functions representing the solution
+                bcs: List of Dirichlet boundary conditions
+                max_iterations: Maximum number of iterations in Newton solver
+                petsc_options: PETSc options for Krylov subspace solver.
+                error_on_nonconvergence: Raise an error if the linear solver
+                    does not converge or Newton solver doesn't converge
+            """
+            # Compile forms if not compiled. Will throw error it requires entity maps
+            self._F = dolfinx.fem.form(F)
+            self._J = dolfinx.fem.form(J)
 
-        # Create PETSc objects for block assembly
-        try:
-            self.b = dolfinx.fem.petsc.create_vector_block(self._F)
-            self.A = dolfinx.fem.petsc.create_matrix_block(self._J)
-            self.dx = dolfinx.fem.petsc.create_vector_block(self._F)
-            self.x = dolfinx.fem.petsc.create_vector_block(self._F)
-        except AttributeError:
-            self.b = dolfinx.fem.petsc.create_vector(self._F, kind="mpi")
-            self.A = dolfinx.fem.petsc.create_matrix(self._J, kind="mpi")
-            self.dx = dolfinx.fem.petsc.create_vector(self._F, kind="mpi")
-            self.x = dolfinx.fem.petsc.create_vector(self._F, kind="mpi")
+            # Store solution and accessible/modifiable properties
+            self._pre_solve_callback = None
+            self._post_solve_callback = None
+            self.max_iterations = max_iterations
+            self._error_on_convergence = error_on_nonconvergence
+            self.bcs = [] if bcs is None else bcs
+            self.w = w
 
-            self._maps = [
-                (
-                    form.function_spaces[0].dofmaps(0).index_map,
-                    form.function_spaces[0].dofmaps(0).index_map_bs,
-                )
-                for form in self.F
-            ]
-
-        # Set PETSc options
-        opts = PETSc.Options()
-        if petsc_options is not None:
-            for k, v in petsc_options.items():
-                opts[k] = v
-
-        # Define KSP solver
-        self._solver = PETSc.KSP().create(self.b.getComm().tompi4py())
-        self._solver.setOperators(self.A)
-        self._solver.setFromOptions()
-
-        # Set matrix and vector PETSc options
-        self.A.setFromOptions()
-        self.b.setFromOptions()
-
-    def set_pre_solve_callback(self, callback: Callable[["NewtonSolver"], None]):
-        """Set a callback function that is called before each Newton iteration."""
-        self._pre_solve_callback = callback
-
-    def set_post_solve_callback(self, callback: Callable[["NewtonSolver"], None]):
-        """Set a callback function that is called after each Newton iteration."""
-        self._post_solve_callback = callback
-
-    def solve(self, atol=1e-6, rtol=1e-8, beta=1.0) -> int:
-        """Solve the nonlinear problem using Newton's method.
-
-        Args:
-            atol: Absolute tolerance for the update.
-            rtol: Relative tolerance for the update.
-            beta: Damping parameter for the update.
-
-        Returns:
-            The number of Newton iterations used to converge.
-
-        Note:
-            The tolerance is on the 0-norm of the update.
-        """
-        i = 1
-
-        while i <= self.max_iterations:
-            if self._pre_solve_callback is not None:
-                self._pre_solve_callback(self)
-
-            # Pack constants and coefficients
+            # Create PETSc objects for block assembly
             try:
-                constants_L = dolfinx.fem.pack_constants(self._F)
-                coeffs_L = dolfinx.fem.pack_coefficients(self._F)
-                constants_a = [
-                    dolfinx.fem.pack_constants(form)
-                    if form is not None
-                    else np.array([], dtype=self.x.array.dtype)
-                    for form in self._J
-                ]
-                coeffs_a = [
-                    {} if form is None else dolfinx.fem.pack_coefficients(form) for form in self._J
-                ]
+                self.b = dolfinx.fem.petsc.create_vector_block(self._F)
+                self.A = dolfinx.fem.petsc.create_matrix_block(self._J)
+                self.dx = dolfinx.fem.petsc.create_vector_block(self._F)
+                self.x = dolfinx.fem.petsc.create_vector_block(self._F)
             except AttributeError:
-                # NOTE: DOLFINx 0.9 compatibility
-                # Pack constants and coefficients
-                constants_L = [
-                    form and dolfinx.cpp.fem.pack_constants(form._cpp_object) for form in self._F
+                self.b = dolfinx.fem.petsc.create_vector(self._F, kind="mpi")
+                self.A = dolfinx.fem.petsc.create_matrix(self._J, kind="mpi")
+                self.dx = dolfinx.fem.petsc.create_vector(self._F, kind="mpi")
+                self.x = dolfinx.fem.petsc.create_vector(self._F, kind="mpi")
+
+                self._maps = [
+                    (
+                        form.function_spaces[0].dofmaps(0).index_map,
+                        form.function_spaces[0].dofmaps(0).index_map_bs,
+                    )
+                    for form in self.F
                 ]
-                coeffs_L = [dolfinx.cpp.fem.pack_coefficients(form._cpp_object) for form in self._F]
-                constants_a = [
-                    [
-                        dolfinx.cpp.fem.pack_constants(form._cpp_object)
+
+            # Set PETSc options
+            opts = PETSc.Options()
+            if petsc_options is not None:
+                for k, v in petsc_options.items():
+                    opts[k] = v
+
+            # Define KSP solver
+            self._solver = PETSc.KSP().create(self.b.getComm().tompi4py())
+            self._solver.setOperators(self.A)
+            self._solver.setFromOptions()
+
+            # Set matrix and vector PETSc options
+            self.A.setFromOptions()
+            self.b.setFromOptions()
+
+        def set_pre_solve_callback(self, callback: Callable[["NewtonSolver"], None]):
+            """Set a callback function that is called before each Newton iteration."""
+            self._pre_solve_callback = callback
+
+        def set_post_solve_callback(self, callback: Callable[["NewtonSolver"], None]):
+            """Set a callback function that is called after each Newton iteration."""
+            self._post_solve_callback = callback
+
+        def solve(self, atol=1e-6, rtol=1e-8, beta=1.0) -> int:
+            """Solve the nonlinear problem using Newton's method.
+
+            Args:
+                atol: Absolute tolerance for the update.
+                rtol: Relative tolerance for the update.
+                beta: Damping parameter for the update.
+
+            Returns:
+                The number of Newton iterations used to converge.
+
+            Note:
+                The tolerance is on the 0-norm of the update.
+            """
+            i = 1
+
+            while i <= self.max_iterations:
+                if self._pre_solve_callback is not None:
+                    self._pre_solve_callback(self)
+
+                # Pack constants and coefficients
+                try:
+                    constants_L = dolfinx.fem.pack_constants(self._F)
+                    coeffs_L = dolfinx.fem.pack_coefficients(self._F)
+                    constants_a = [
+                        dolfinx.fem.pack_constants(form)
                         if form is not None
                         else np.array([], dtype=self.x.array.dtype)
-                        for form in forms
+                        for form in self._J
                     ]
-                    for forms in self._J
-                ]
-                coeffs_a = [
+                    coeffs_a = [
+                        {} if form is None else dolfinx.fem.pack_coefficients(form)
+                        for form in self._J
+                    ]
+                except AttributeError:
+                    # NOTE: DOLFINx 0.9 compatibility
+                    # Pack constants and coefficients
+                    constants_L = [
+                        form and dolfinx.cpp.fem.pack_constants(form._cpp_object)
+                        for form in self._F
+                    ]
+                    coeffs_L = [
+                        dolfinx.cpp.fem.pack_coefficients(form._cpp_object) for form in self._F
+                    ]
+                    constants_a = [
+                        [
+                            dolfinx.cpp.fem.pack_constants(form._cpp_object)
+                            if form is not None
+                            else np.array([], dtype=self.x.array.dtype)
+                            for form in forms
+                        ]
+                        for forms in self._J
+                    ]
+                    coeffs_a = [
+                        [
+                            {}
+                            if form is None
+                            else dolfinx.cpp.fem.pack_coefficients(form._cpp_object)
+                            for form in forms
+                        ]
+                        for forms in self._J
+                    ]
+                # Scatter previous solution `w` to `self.x`, the blocked version used for lifting
+                dolfinx.cpp.la.petsc.scatter_local_vectors(
+                    self.x,
+                    [si.x.petsc_vec.array_r for si in self.w],
                     [
-                        {} if form is None else dolfinx.cpp.fem.pack_coefficients(form._cpp_object)
-                        for form in forms
-                    ]
-                    for forms in self._J
+                        (
+                            si.function_space.dofmap.index_map,
+                            si.function_space.dofmap.index_map_bs,
+                        )
+                        for si in self.w
+                    ],
+                )
+                self.x.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+
+                # Assemble F(u_{i-1}) - J(u_D - u_{i-1}) and set du|_bc= u_D - u_{i-1}
+                with self.b.localForm() as b_local:
+                    b_local.set(0.0)
+                try:
+                    dolfinx.fem.petsc.assemble_vector_block(
+                        self.b,
+                        self._F,
+                        self._J,
+                        bcs=self.bcs,
+                        x0=self.x,
+                        coeffs_a=coeffs_a,
+                        constants_a=constants_a,
+                        coeffs_L=coeffs_L,
+                        constants_L=constants_L,
+                        # dolfinx 0.8 compatibility
+                        # this is called 'scale' in 0.8, 'alpha' in 0.9
+                        **{_alpha_kw: -1.0},
+                    )
+                except AttributeError:
+                    dolfinx.fem.petsc.assemble_vector(
+                        self.b, self._F, coeffs=coeffs_L, constants=constants_L
+                    )
+                    bcs1 = dolfinx.fem.bcs_by_block(
+                        dolfinx.fem.extract_function_spaces(self._J, 1), self.bcs
+                    )
+                    dolfinx.fem.petsc.apply_lifting(
+                        self.b,
+                        self._J,
+                        bcs=bcs1,
+                        x0=self.x,
+                        coeffs=coeffs_a,
+                        constants=constants_a,
+                        alpha=-1.0,
+                    )
+                    self.b.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
+                    bcs0 = dolfinx.fem.bcs_by_block(
+                        dolfinx.fem.extract_function_spaces(self._F), self.bcs
+                    )
+                    dolfinx.fem.petsc.set_bc(self.b, bcs0, x0=self.x, alpha=-1.0)
+                    self.b.ghostUpdate(PETSc.InsertMode.INSERT_VALUES, PETSc.ScatterMode.FORWARD)
+
+                # Assemble Jacobian
+                self.A.zeroEntries()
+                try:
+                    dolfinx.fem.petsc.assemble_matrix_block(
+                        self.A, self._J, bcs=self.bcs, constants=constants_a, coeffs=coeffs_a
+                    )
+                except AttributeError:
+                    dolfinx.fem.petsc.assemble_matrix(
+                        self.A, self._J, self.bcs, coeffs=coeffs_a, constants=constants_a
+                    )
+                self.A.assemble()
+
+                self._solver.solve(self.b, self.dx)
+                if self._error_on_convergence:
+                    if (status := self._solver.getConvergedReason()) <= 0:
+                        raise RuntimeError(f"Linear solver did not converge, got reason: {status}")
+
+                # Update solution
+                offset_start = 0
+                for s in self.w:
+                    num_sub_dofs = (
+                        s.function_space.dofmap.index_map.size_local
+                        * s.function_space.dofmap.index_map_bs
+                    )
+                    s.x.petsc_vec.array_w[:num_sub_dofs] -= (
+                        beta * self.dx.array_r[offset_start : offset_start + num_sub_dofs]
+                    )
+                    s.x.petsc_vec.ghostUpdate(
+                        addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD
+                    )
+                    offset_start += num_sub_dofs
+
+                if self._post_solve_callback is not None:
+                    self._post_solve_callback(self)
+
+                # Compute norm of update
+                residual = self.dx.norm(PETSc.NormType.NORM_2)
+                if i == 1:
+                    self.residual_0 = residual
+                relative_residual = residual / max(self.residual_0, atol)
+
+                logger.info(
+                    f"Newton iteration {i}"
+                    f": r (abs) = {residual} (tol={atol}), "
+                    f"r (rel) = {relative_residual} (tol={rtol})"
+                )
+                if relative_residual < rtol or residual < atol:
+                    return i
+                i += 1
+
+            if self._error_on_convergence:
+                raise RuntimeError("Newton solver did not converge")
+            else:
+                return self.max_iterations
+
+        @property
+        def F(self):
+            """The list of residuals where each entry is a ``dolfinx.fem.Form``."""
+            return self._F
+
+        @property
+        def J(self):
+            """
+            The Jacobian blocks represented as lists of lists where each entry
+            is a ``dolfinx.fem.Form``.
+            """
+            return self._J
+
+        def __del__(self):
+            """Clean up the solver by destroying PETSc objects."""
+            self.A.destroy()
+            self.b.destroy()
+            self.dx.destroy()
+            self._solver.destroy()
+            self.x.destroy()
+
+    class BlockedNewtonSolver(dolfinx.cpp.nls.petsc.NewtonSolver):
+        def __init__(
+            self,
+            F: list[ufl.form.Form],
+            u: list[dolfinx.fem.Function],
+            bcs: list[dolfinx.fem.DirichletBC] = [],
+            J: list[list[ufl.form.Form]] | None = None,
+            form_compiler_options: dict | None = None,
+            jit_options: dict | None = None,
+            petsc_options: dict | None = None,
+            entity_maps: dict | None = None,
+        ):
+            """Initialize solver for solving a non-linear problem using Newton's method.
+            Args:
+                F: List of PDE residuals [F_0(u, v_0), F_1(u, v_1), ...]
+                u: List of unknown functions u=[u_0, u_1, ...]
+                bcs: List of Dirichlet boundary conditions
+                J: UFL representation of the Jacobian (Optional)
+                    Note:
+                        If not provided, the Jacobian will be computed using the
+                        assumption that the test functions come from a ``ufl.MixedFunctionSpace``
+                form_compiler_options: Options used in FFCx
+                    compilation of this form. Run ``ffcx --help`` at the
+                    command line to see all available options.
+                jit_options: Options used in CFFI JIT compilation of C
+                    code generated by FFCx. See ``python/dolfinx/jit.py``
+                    for all available options. Takes priority over all
+                    other option values.
+                petsc_options:
+                    Options passed to the PETSc Krylov solver.
+                entity_maps: Maps used to map entities between different meshes.
+                    Only needed if the forms have not been compiled a priori,
+                    and has coefficients, test, or trial functions that are defined on different meshes.
+            """
+            # Initialize base class
+            super().__init__(u[0].function_space.mesh.comm)
+
+            # Set PETSc options for Krylov solver
+            prefix = self.krylov_solver.getOptionsPrefix()
+            if prefix is None:
+                prefix = ""
+            if petsc_options is not None:
+                # Set PETSc options
+                opts = PETSc.Options()
+                opts.prefixPush(prefix)
+                for k, v in petsc_options.items():
+                    opts[k] = v
+                opts.prefixPop()
+                self.krylov_solver.setFromOptions()
+            self._F = dolfinx.fem.form(
+                F,
+                form_compiler_options=form_compiler_options,
+                jit_options=jit_options,
+                entity_maps=entity_maps,
+            )
+
+            # Create the Jacobian matrix, dF/du
+            if J is None:
+                if _v(dolfinx.__version__) < _v("0.9"):
+                    raise RuntimeError(
+                        "Automatic computation of Jacobian for blocked problem is only"
+                        + "supported in DOLFINx 0.9 and later"
+                    )
+                du = ufl.TrialFunctions(ufl.MixedFunctionSpace(*[ui.function_space for ui in u]))
+                J = ufl.extract_blocks(
+                    sum(ufl.derivative(sum(F), u[i], du[i]) for i in range(len(u)))
+                )
+            self._a = dolfinx.fem.form(
+                J,
+                form_compiler_options=form_compiler_options,
+                jit_options=jit_options,
+                entity_maps=entity_maps,
+            )
+
+            self._bcs = bcs
+            self._u = u
+            self._pre_solve_callback: Callable[["BlockedNewtonSolver"], None] | None = None
+            self._post_solve_callback: Callable[["BlockedNewtonSolver"], None] | None = None
+
+            # Create structures for holding arrays and matrix
+            try:
+                self._b = dolfinx.fem.petsc.create_vector_block(self._F)
+                self._J = dolfinx.fem.petsc.create_matrix_block(self._a)
+                self._dx = dolfinx.fem.petsc.create_vector_block(self._F)
+                self._x = dolfinx.fem.petsc.create_vector_block(self._F)
+            except AttributeError:
+                self._b = dolfinx.fem.petsc.create_vector(self._F, kind="mpi")
+                self._J = dolfinx.fem.petsc.create_matrix(self._a, kind="mpi")
+                self._dx = dolfinx.fem.petsc.create_vector(self._F, kind="mpi")
+                self._x = dolfinx.fem.petsc.create_vector(self._F, kind="mpi")
+
+                self._maps = [
+                    (
+                        form.function_spaces[0].dofmaps(0).index_map,
+                        form.function_spaces[0].dofmaps(0).index_map_bs,
+                    )
+                    for form in self._F
                 ]
-            # Scatter previous solution `w` to `self.x`, the blocked version used for lifting
+
+            self._J.setOptionsPrefix(prefix)
+            self._J.setFromOptions()
+
+            self.setJ(self._assemble_jacobian, self._J)
+            self.setF(self._assemble_residual, self._b)
+            self.set_form(self._pre_newton_iteration)
+            self.set_update(self._update_function)
+
+        def set_pre_solve_callback(self, callback: Callable[["BlockedNewtonSolver"], None]):
+            """Set a callback function that is called before each Newton iteration."""
+            self._pre_solve_callback = callback
+
+        def set_post_solve_callback(self, callback: Callable[["BlockedNewtonSolver"], None]):
+            """Set a callback function that is called after each Newton iteration."""
+            self._post_solve_callback = callback
+
+        @property
+        def L(self) -> list[dolfinx.fem.Form]:
+            """Compiled linear form (the residual form)"""
+            return self._F
+
+        @property
+        def a(self) -> list[list[dolfinx.fem.Form]]:
+            """Compiled bilinear form (the Jacobian form)"""
+            return self._a
+
+        @property
+        def u(self):
+            return self._u
+
+        def __del__(self):
+            self._J.destroy()
+            self._b.destroy()
+            self._dx.destroy()
+            self._x.destroy()
+
+        def _pre_newton_iteration(self, x: PETSc.Vec) -> None:
+            """Function called before the residual or Jacobian is
+            computed.
+            Args:
+            x: The vector containing the latest solution
+            """
+            if self._pre_solve_callback is not None:
+                self._pre_solve_callback(self)
+            # Scatter previous solution `u=[u_0, ..., u_N]` to `x`; the
+            # blocked version used for lifting
             dolfinx.cpp.la.petsc.scatter_local_vectors(
-                self.x,
-                [si.x.petsc_vec.array_r for si in self.w],
+                x,
+                [ui.x.petsc_vec.array_r for ui in self._u],
                 [
                     (
-                        si.function_space.dofmap.index_map,
-                        si.function_space.dofmap.index_map_bs,
+                        ui.function_space.dofmap.index_map,
+                        ui.function_space.dofmap.index_map_bs,
                     )
-                    for si in self.w
+                    for ui in self._u
                 ],
             )
-            self.x.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+            x.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
 
+        def _assemble_residual(self, x: PETSc.Vec, b: PETSc.Vec) -> None:
+            """Assemble the residual F into the vector b.
+            Args:
+                x: The vector containing the latest solution
+                b: Vector to assemble the residual into
+            """
             # Assemble F(u_{i-1}) - J(u_D - u_{i-1}) and set du|_bc= u_D - u_{i-1}
-            with self.b.localForm() as b_local:
+            with b.localForm() as b_local:
                 b_local.set(0.0)
             try:
                 dolfinx.fem.petsc.assemble_vector_block(
-                    self.b,
+                    b,
                     self._F,
-                    self._J,
-                    bcs=self.bcs,
-                    x0=self.x,
-                    coeffs_a=coeffs_a,
-                    constants_a=constants_a,
-                    coeffs_L=coeffs_L,
-                    constants_L=constants_L,
+                    self._a,
+                    bcs=self._bcs,
+                    x0=x,
                     # dolfinx 0.8 compatibility
                     # this is called 'scale' in 0.8, 'alpha' in 0.9
                     **{_alpha_kw: -1.0},
                 )
             except AttributeError:
-                dolfinx.fem.petsc.assemble_vector(
-                    self.b, self._F, coeffs=coeffs_L, constants=constants_L
-                )
+                dolfinx.fem.petsc.assemble_vector(b, self._F)
                 bcs1 = dolfinx.fem.bcs_by_block(
-                    dolfinx.fem.extract_function_spaces(self._J, 1), self.bcs
+                    dolfinx.fem.extract_function_spaces(self._a, 1), self._bcs
                 )
-                dolfinx.fem.petsc.apply_lifting(
-                    self.b,
-                    self._J,
-                    bcs=bcs1,
-                    x0=self.x,
-                    coeffs=coeffs_a,
-                    constants=constants_a,
-                    alpha=-1.0,
-                )
-                self.b.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
+                dolfinx.fem.petsc.apply_lifting(b, self._a, bcs=bcs1, x0=x, alpha=-1.0)
+                b.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
                 bcs0 = dolfinx.fem.bcs_by_block(
-                    dolfinx.fem.extract_function_spaces(self._F), self.bcs
+                    dolfinx.fem.extract_function_spaces(self._F), self._bcs
                 )
-                dolfinx.fem.petsc.set_bc(self.b, bcs0, x0=self.x, alpha=-1.0)
-                self.b.ghostUpdate(PETSc.InsertMode.INSERT_VALUES, PETSc.ScatterMode.FORWARD)
+                dolfinx.fem.petsc.set_bc(b, bcs0, x0=x, alpha=-1.0)
+            b.ghostUpdate(PETSc.InsertMode.INSERT_VALUES, PETSc.ScatterMode.FORWARD)
 
+        def _assemble_jacobian(self, x: PETSc.Vec, A: PETSc.Mat) -> None:
+            """Assemble the Jacobian matrix.
+            Args:
+                x: The vector containing the latest solution
+            """
             # Assemble Jacobian
-            self.A.zeroEntries()
+            A.zeroEntries()
             try:
-                dolfinx.fem.petsc.assemble_matrix_block(
-                    self.A, self._J, bcs=self.bcs, constants=constants_a, coeffs=coeffs_a
-                )
+                dolfinx.fem.petsc.assemble_matrix_block(A, self._a, bcs=self._bcs)
             except AttributeError:
-                dolfinx.fem.petsc.assemble_matrix(
-                    self.A, self._J, self.bcs, coeffs=coeffs_a, constants=constants_a
-                )
-            self.A.assemble()
+                dolfinx.fem.petsc.assemble_matrix(A, self._a, self._bcs)
+            A.assemble()
 
-            self._solver.solve(self.b, self.dx)
-            if self._error_on_convergence:
-                if (status := self._solver.getConvergedReason()) <= 0:
-                    raise RuntimeError(f"Linear solver did not converge, got reason: {status}")
-
+        def _update_function(self, solver, dx: PETSc.Vec, x: PETSc.Vec):
+            if self._post_solve_callback is not None:
+                self._post_solve_callback(self)
             # Update solution
             offset_start = 0
-            for s in self.w:
-                num_sub_dofs = (
-                    s.function_space.dofmap.index_map.size_local
-                    * s.function_space.dofmap.index_map_bs
+            for ui in self._u:
+                Vi = ui.function_space
+                num_sub_dofs = Vi.dofmap.index_map.size_local * Vi.dofmap.index_map_bs
+                ui.x.petsc_vec.array_w[:num_sub_dofs] -= (
+                    self.relaxation_parameter
+                    * dx.array_r[offset_start : offset_start + num_sub_dofs]
                 )
-                s.x.petsc_vec.array_w[:num_sub_dofs] -= (
-                    beta * self.dx.array_r[offset_start : offset_start + num_sub_dofs]
-                )
-                s.x.petsc_vec.ghostUpdate(
+                ui.x.petsc_vec.ghostUpdate(
                     addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD
                 )
                 offset_start += num_sub_dofs
 
-            if self._post_solve_callback is not None:
-                self._post_solve_callback(self)
-
-            # Compute norm of update
-            residual = self.dx.norm(PETSc.NormType.NORM_2)
-            if i == 1:
-                self.residual_0 = residual
-            relative_residual = residual / max(self.residual_0, atol)
-
-            logger.info(
-                f"Newton iteration {i}"
-                f": r (abs) = {residual} (tol={atol}), "
-                f"r (rel) = {relative_residual} (tol={rtol})"
-            )
-            if relative_residual < rtol or residual < atol:
-                return i
-            i += 1
-
-        if self._error_on_convergence:
-            raise RuntimeError("Newton solver did not converge")
-        else:
-            return self.max_iterations
-
-    @property
-    def F(self):
-        """The list of residuals where each entry is a ``dolfinx.fem.Form``."""
-        return self._F
-
-    @property
-    def J(self):
-        """
-        The Jacobian blocks represented as lists of lists where each entry
-        is a ``dolfinx.fem.Form``.
-        """
-        return self._J
-
-    def __del__(self):
-        """Clean up the solver by destroying PETSc objects."""
-        self.A.destroy()
-        self.b.destroy()
-        self.dx.destroy()
-        self._solver.destroy()
-        self.x.destroy()
-
-
-class BlockedNewtonSolver(dolfinx.cpp.nls.petsc.NewtonSolver):
-    def __init__(
-        self,
-        F: list[ufl.form.Form],
-        u: list[dolfinx.fem.Function],
-        bcs: list[dolfinx.fem.DirichletBC] = [],
-        J: list[list[ufl.form.Form]] | None = None,
-        form_compiler_options: dict | None = None,
-        jit_options: dict | None = None,
-        petsc_options: dict | None = None,
-        entity_maps: dict | None = None,
-    ):
-        """Initialize solver for solving a non-linear problem using Newton's method.
-        Args:
-            F: List of PDE residuals [F_0(u, v_0), F_1(u, v_1), ...]
-            u: List of unknown functions u=[u_0, u_1, ...]
-            bcs: List of Dirichlet boundary conditions
-            J: UFL representation of the Jacobian (Optional)
-                Note:
-                    If not provided, the Jacobian will be computed using the
-                    assumption that the test functions come from a ``ufl.MixedFunctionSpace``
-            form_compiler_options: Options used in FFCx
-                compilation of this form. Run ``ffcx --help`` at the
-                command line to see all available options.
-            jit_options: Options used in CFFI JIT compilation of C
-                code generated by FFCx. See ``python/dolfinx/jit.py``
-                for all available options. Takes priority over all
-                other option values.
-            petsc_options:
-                Options passed to the PETSc Krylov solver.
-            entity_maps: Maps used to map entities between different meshes.
-                Only needed if the forms have not been compiled a priori,
-                and has coefficients, test, or trial functions that are defined on different meshes.
-        """
-        # Initialize base class
-        super().__init__(u[0].function_space.mesh.comm)
-
-        # Set PETSc options for Krylov solver
-        prefix = self.krylov_solver.getOptionsPrefix()
-        if prefix is None:
-            prefix = ""
-        if petsc_options is not None:
-            # Set PETSc options
-            opts = PETSc.Options()
-            opts.prefixPush(prefix)
-            for k, v in petsc_options.items():
-                opts[k] = v
-            opts.prefixPop()
-            self.krylov_solver.setFromOptions()
-        self._F = dolfinx.fem.form(
-            F,
-            form_compiler_options=form_compiler_options,
-            jit_options=jit_options,
-            entity_maps=entity_maps,
-        )
-
-        # Create the Jacobian matrix, dF/du
-        if J is None:
-            if _v(dolfinx.__version__) < _v("0.9"):
-                raise RuntimeError(
-                    "Automatic computation of Jacobian for blocked problem is only"
-                    + "supported in DOLFINx 0.9 and later"
-                )
-            du = ufl.TrialFunctions(ufl.MixedFunctionSpace(*[ui.function_space for ui in u]))
-            J = ufl.extract_blocks(sum(ufl.derivative(sum(F), u[i], du[i]) for i in range(len(u))))
-        self._a = dolfinx.fem.form(
-            J,
-            form_compiler_options=form_compiler_options,
-            jit_options=jit_options,
-            entity_maps=entity_maps,
-        )
-
-        self._bcs = bcs
-        self._u = u
-        self._pre_solve_callback: Callable[["BlockedNewtonSolver"], None] | None = None
-        self._post_solve_callback: Callable[["BlockedNewtonSolver"], None] | None = None
-
-        # Create structures for holding arrays and matrix
-        try:
-            self._b = dolfinx.fem.petsc.create_vector_block(self._F)
-            self._J = dolfinx.fem.petsc.create_matrix_block(self._a)
-            self._dx = dolfinx.fem.petsc.create_vector_block(self._F)
-            self._x = dolfinx.fem.petsc.create_vector_block(self._F)
-        except AttributeError:
-            self._b = dolfinx.fem.petsc.create_vector(self._F, kind="mpi")
-            self._J = dolfinx.fem.petsc.create_matrix(self._a, kind="mpi")
-            self._dx = dolfinx.fem.petsc.create_vector(self._F, kind="mpi")
-            self._x = dolfinx.fem.petsc.create_vector(self._F, kind="mpi")
-
-            self._maps = [
-                (
-                    form.function_spaces[0].dofmaps(0).index_map,
-                    form.function_spaces[0].dofmaps(0).index_map_bs,
-                )
-                for form in self._F
-            ]
-
-        self._J.setOptionsPrefix(prefix)
-        self._J.setFromOptions()
-
-        self.setJ(self._assemble_jacobian, self._J)
-        self.setF(self._assemble_residual, self._b)
-        self.set_form(self._pre_newton_iteration)
-        self.set_update(self._update_function)
-
-    def set_pre_solve_callback(self, callback: Callable[["BlockedNewtonSolver"], None]):
-        """Set a callback function that is called before each Newton iteration."""
-        self._pre_solve_callback = callback
-
-    def set_post_solve_callback(self, callback: Callable[["BlockedNewtonSolver"], None]):
-        """Set a callback function that is called after each Newton iteration."""
-        self._post_solve_callback = callback
-
-    @property
-    def L(self) -> list[dolfinx.fem.Form]:
-        """Compiled linear form (the residual form)"""
-        return self._F
-
-    @property
-    def a(self) -> list[list[dolfinx.fem.Form]]:
-        """Compiled bilinear form (the Jacobian form)"""
-        return self._a
-
-    @property
-    def u(self):
-        return self._u
-
-    def __del__(self):
-        self._J.destroy()
-        self._b.destroy()
-        self._dx.destroy()
-        self._x.destroy()
-
-    def _pre_newton_iteration(self, x: PETSc.Vec) -> None:
-        """Function called before the residual or Jacobian is
-        computed.
-        Args:
-           x: The vector containing the latest solution
-        """
-        if self._pre_solve_callback is not None:
-            self._pre_solve_callback(self)
-        # Scatter previous solution `u=[u_0, ..., u_N]` to `x`; the
-        # blocked version used for lifting
-        dolfinx.cpp.la.petsc.scatter_local_vectors(
-            x,
-            [ui.x.petsc_vec.array_r for ui in self._u],
-            [
-                (
-                    ui.function_space.dofmap.index_map,
-                    ui.function_space.dofmap.index_map_bs,
-                )
-                for ui in self._u
-            ],
-        )
-        x.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
-
-    def _assemble_residual(self, x: PETSc.Vec, b: PETSc.Vec) -> None:
-        """Assemble the residual F into the vector b.
-        Args:
-            x: The vector containing the latest solution
-            b: Vector to assemble the residual into
-        """
-        # Assemble F(u_{i-1}) - J(u_D - u_{i-1}) and set du|_bc= u_D - u_{i-1}
-        with b.localForm() as b_local:
-            b_local.set(0.0)
-        try:
-            dolfinx.fem.petsc.assemble_vector_block(
-                b,
-                self._F,
-                self._a,
-                bcs=self._bcs,
-                x0=x,
-                # dolfinx 0.8 compatibility
-                # this is called 'scale' in 0.8, 'alpha' in 0.9
-                **{_alpha_kw: -1.0},
-            )
-        except AttributeError:
-            dolfinx.fem.petsc.assemble_vector(b, self._F)
-            bcs1 = dolfinx.fem.bcs_by_block(
-                dolfinx.fem.extract_function_spaces(self._a, 1), self._bcs
-            )
-            dolfinx.fem.petsc.apply_lifting(b, self._a, bcs=bcs1, x0=x, alpha=-1.0)
-            b.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
-            bcs0 = dolfinx.fem.bcs_by_block(dolfinx.fem.extract_function_spaces(self._F), self._bcs)
-            dolfinx.fem.petsc.set_bc(b, bcs0, x0=x, alpha=-1.0)
-        b.ghostUpdate(PETSc.InsertMode.INSERT_VALUES, PETSc.ScatterMode.FORWARD)
-
-    def _assemble_jacobian(self, x: PETSc.Vec, A: PETSc.Mat) -> None:
-        """Assemble the Jacobian matrix.
-        Args:
-            x: The vector containing the latest solution
-        """
-        # Assemble Jacobian
-        A.zeroEntries()
-        try:
-            dolfinx.fem.petsc.assemble_matrix_block(A, self._a, bcs=self._bcs)
-        except AttributeError:
-            dolfinx.fem.petsc.assemble_matrix(A, self._a, self._bcs)
-        A.assemble()
-
-    def _update_function(self, solver, dx: PETSc.Vec, x: PETSc.Vec):
-        if self._post_solve_callback is not None:
-            self._post_solve_callback(self)
-        # Update solution
-        offset_start = 0
-        for ui in self._u:
-            Vi = ui.function_space
-            num_sub_dofs = Vi.dofmap.index_map.size_local * Vi.dofmap.index_map_bs
-            ui.x.petsc_vec.array_w[:num_sub_dofs] -= (
-                self.relaxation_parameter * dx.array_r[offset_start : offset_start + num_sub_dofs]
-            )
-            ui.x.petsc_vec.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
-            offset_start += num_sub_dofs
-
-    def solve(self):
-        """Solve non-linear problem into function. Returns the number
-        of iterations and if the solver converged."""
-        n, converged = super().solve(self._x)
-        self._x.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
-        return n, converged
+        def solve(self):
+            """Solve non-linear problem into function. Returns the number
+            of iterations and if the solver converged."""
+            n, converged = super().solve(self._x)
+            self._x.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+            return n, converged

--- a/src/scifem/solvers.py
+++ b/src/scifem/solvers.py
@@ -197,7 +197,7 @@ class NewtonSolver:
                 bcs0 = dolfinx.fem.bcs_by_block(
                     dolfinx.fem.extract_function_spaces(self._F), self.bcs
                 )
-                dolfinx.fem.petsc.set_bc(self.b, bcs0, x0=self.x, alpha=-1.)
+                dolfinx.fem.petsc.set_bc(self.b, bcs0, x0=self.x, alpha=-1.0)
                 self.b.ghostUpdate(PETSc.InsertMode.INSERT_VALUES, PETSc.ScatterMode.FORWARD)
 
             # Assemble Jacobian

--- a/src/scifem/solvers.py
+++ b/src/scifem/solvers.py
@@ -352,7 +352,8 @@ else:
                     Options passed to the PETSc Krylov solver.
                 entity_maps: Maps used to map entities between different meshes.
                     Only needed if the forms have not been compiled a priori,
-                    and has coefficients, test, or trial functions that are defined on different meshes.
+                    and has coefficients, test, or trial functions that are defined on
+                    different meshes.
             """
             # Initialize base class
             super().__init__(u[0].function_space.mesh.comm)

--- a/src/scifem/solvers.py
+++ b/src/scifem/solvers.py
@@ -443,7 +443,7 @@ class BlockedNewtonSolver(dolfinx.cpp.nls.petsc.NewtonSolver):
                                             alpha=-1.)
             b.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
             bcs0 = dolfinx.fem.bcs_by_block(dolfinx.fem.extract_function_spaces(self._F), self._bcs)
-            dolfinx.fem.petsc.set_bc(b, bcs0)
+            dolfinx.fem.petsc.set_bc(b, bcs0, x0=x, alpha=-1.)
         b.ghostUpdate(PETSc.InsertMode.INSERT_VALUES, PETSc.ScatterMode.FORWARD)
 
     def _assemble_jacobian(self, x: PETSc.Vec, A: PETSc.Mat) -> None:

--- a/src/scifem/solvers.py
+++ b/src/scifem/solvers.py
@@ -10,22 +10,7 @@ import dolfinx
 
 __all__ = ["NewtonSolver", "BlockedNewtonSolver"]
 
-if not dolfinx.has_petsc4py or dolfinx.has_petsc:
-
-    class NewtonSolver:
-        def __init__(self, *args, **kwargs):
-            raise RuntimeError(
-                "NewtonSolver is not available in this version of DOLFINx. "
-                "Please install a version of DOLFINx with PETSc4py support."
-            )
-
-    class BlockedNewtonSolver:
-        def __init__(self, *args, **kwargs):
-            raise RuntimeError(
-                "BlockedNewtonSolver is not available in this version of DOLFINx. "
-                "Please install a version of DOLFINx with PETSc4py support."
-            )
-else:
+if dolfinx.has_petsc4py and dolfinx.has_petsc:
     logger = logging.getLogger(__name__)
     from petsc4py import PETSc
     import dolfinx.fem.petsc
@@ -548,3 +533,19 @@ else:
             n, converged = super().solve(self._x)
             self._x.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
             return n, converged
+
+else:
+
+    class NewtonSolver:  # type: ignore[no-redef]
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                "NewtonSolver is not available in this version of DOLFINx. "
+                "Please install a version of DOLFINx with PETSc4py support."
+            )
+
+    class BlockedNewtonSolver:  # type: ignore[no-redef]
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                "BlockedNewtonSolver is not available in this version of DOLFINx. "
+                "Please install a version of DOLFINx with PETSc4py support."
+            )

--- a/src/scifem/solvers.py
+++ b/src/scifem/solvers.py
@@ -146,6 +146,7 @@ class NewtonSolver:
                     {} if form is None else dolfinx.fem.pack_coefficients(form) for form in self._J
                 ]
             except AttributeError:
+                # NOTE: DOLFINx 0.9 compatibility
                 # Pack constants and coefficients
                 constants_L = [
                     form and dolfinx.cpp.fem.pack_constants(form._cpp_object) for form in self._F

--- a/src/scifem/solvers.py
+++ b/src/scifem/solvers.py
@@ -138,7 +138,7 @@ class NewtonSolver:
             constants_a = [
                 dolfinx.fem.pack_constants(form)
                 if form is not None
-                else np.array([], dtype=self._b.x.array.dtype)
+                else np.array([], dtype=self.x.array.dtype)
                 for form in self._J
             ]  # type: ignore
             coeffs_a = [

--- a/src/scifem/solvers.py
+++ b/src/scifem/solvers.py
@@ -141,7 +141,7 @@ class NewtonSolver:
                     if form is not None
                     else np.array([], dtype=self.x.array.dtype)
                     for form in self._J
-                ]  # type: ignore
+                ]
                 coeffs_a = [
                     {} if form is None else dolfinx.fem.pack_coefficients(form) for form in self._J
                 ]
@@ -156,7 +156,14 @@ class NewtonSolver:
                     [
                         dolfinx.cpp.fem.pack_constants(form._cpp_object)
                         if form is not None
-                        else np.array([], dtype=PETSc.ScalarType)
+                        else np.array([], dtype=self.x.array.dtype)
+                        for form in forms
+                    ]
+                    for forms in self._J
+                ]
+                coeffs_a = [
+                    [
+                        {} if form is None else dolfinx.cpp.fem.pack_coefficients(form._cpp_object)
                         for form in forms
                     ]
                     for forms in self._J

--- a/src/scifem/solvers.py
+++ b/src/scifem/solvers.py
@@ -138,7 +138,7 @@ class NewtonSolver:
             constants_a = [
                 dolfinx.fem.pack_constants(form)
                 if form is not None
-                else np.array([], dtype=b.dtype)
+                else np.array([], dtype=self._b.x.array.dtype)
                 for form in self._J
             ]  # type: ignore
             coeffs_a = [

--- a/src/scifem/solvers.py
+++ b/src/scifem/solvers.py
@@ -197,7 +197,7 @@ class NewtonSolver:
                 bcs0 = dolfinx.fem.bcs_by_block(
                     dolfinx.fem.extract_function_spaces(self._F), self.bcs
                 )
-                dolfinx.fem.petsc.set_bc(self.b, bcs0)
+                dolfinx.fem.petsc.set_bc(self.b, bcs0, x0=self.x, alpha=-1.)
                 self.b.ghostUpdate(PETSc.InsertMode.INSERT_VALUES, PETSc.ScatterMode.FORWARD)
 
             # Assemble Jacobian

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -1,6 +1,7 @@
 from mpi4py import MPI
 
 from scifem import assemble_scalar, norm
+import scifem.petsc
 from dolfinx.mesh import create_unit_square, exterior_facet_indices
 import dolfinx
 import basix.ufl
@@ -123,7 +124,6 @@ def test_norm(norm_type, dtype, gtype):
 )
 def test_lifting_helper(kind, alpha):
     from petsc4py import PETSc
-    import scifem.assembly
     import dolfinx.fem.petsc
 
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 15)

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -114,7 +114,7 @@ def test_norm(norm_type, dtype, gtype):
 
 
 @pytest.mark.skipif(not dolfinx.has_petsc4py, reason="Requires DOLFINX with PETSc4py")
-@pytest.mark.skipit(
+@pytest.mark.skipif(
     hasattr(dolfinx.fem.petsc, "create_matrix_nest"),
     reason="Requires latest version of DOLFINx PETSc API",
 )

--- a/tests/test_blocked_newton_solver.py
+++ b/tests/test_blocked_newton_solver.py
@@ -77,14 +77,14 @@ def test_NewtonSolver(factor, auto_split):
     bc_q = dolfinx.fem.dirichletbc(p_bc, dofs_q)
 
     petsc_options = {"ksp_type": "preonly", "pc_type": "lu", "pc_factor_mat_solver_type": "mumps"}
-    # solver = NewtonSolver(F, J, [u, p], bcs=[bc_q], max_iterations=25, petsc_options=petsc_options)
-    # solver.solve()
+    solver = NewtonSolver(F, J, [u, p], bcs=[bc_q], max_iterations=25, petsc_options=petsc_options)
+    solver.solve()
 
-    # err_u = ufl.inner(u_ex - u, u_ex - u) * ufl.dx
-    # err_p = ufl.inner(p_ex - p, p_ex - p) * ufl.dx
-    # tol = np.finfo(dtype).eps * 1.0e3
-    # assert assemble_scalar(err_u) < tol
-    # assert assemble_scalar(err_p) < tol
+    err_u = ufl.inner(u_ex - u, u_ex - u) * ufl.dx
+    err_p = ufl.inner(p_ex - p, p_ex - p) * ufl.dx
+    tol = np.finfo(dtype).eps * 1.0e3
+    assert assemble_scalar(err_u) < tol
+    assert assemble_scalar(err_p) < tol
 
     # Check consistency with other Newton solver
     blocked_solver = BlockedNewtonSolver(

--- a/tests/test_blocked_newton_solver.py
+++ b/tests/test_blocked_newton_solver.py
@@ -4,7 +4,7 @@ import numpy as np
 import dolfinx
 import dolfinx.nls.petsc
 from petsc4py import PETSc
-from scifem import assemble_scalar, BlockedNewtonSolver
+from scifem import assemble_scalar, BlockedNewtonSolver, NewtonSolver
 import basix.ufl
 import ufl
 import pytest

--- a/tests/test_blocked_newton_solver.py
+++ b/tests/test_blocked_newton_solver.py
@@ -94,7 +94,7 @@ def test_NewtonSolver(factor, auto_split):
     dolfinx.log.set_log_level(dolfinx.log.LogLevel.ERROR)
     u.x.array[:] = factor * 0.1
     p.x.array[:] = factor * 0.02
-    blocked_solver.convergence_criterion = "residual"
+    blocked_solver.convergence_criterion = "incremental"
     dolfinx.log.set_log_level(dolfinx.log.LogLevel.INFO)
     blocked_solver.solve()
 

--- a/tests/test_blocked_newton_solver.py
+++ b/tests/test_blocked_newton_solver.py
@@ -2,31 +2,43 @@ from mpi4py import MPI
 
 import numpy as np
 import dolfinx
+import dolfinx.nls.petsc
 from petsc4py import PETSc
 from scifem import NewtonSolver, assemble_scalar, BlockedNewtonSolver
+import basix.ufl
 import ufl
 import pytest
 from packaging.version import parse as _v
 
 
 @pytest.mark.parametrize("factor", [1, -1])
-def test_NewtonSolver(factor):
+@pytest.mark.parametrize("auto_split", [True, False])
+def test_NewtonSolver(factor, auto_split):
+
+    def left_boundary(x):
+        return np.isclose(x[0], 0.0)
+
     dtype = PETSc.RealType
     ftype = PETSc.ScalarType
     mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 10, 12, dtype=dtype)
-    V = dolfinx.fem.functionspace(mesh, ("Lagrange", 1))
-    Q = dolfinx.fem.functionspace(mesh, ("Lagrange", 2))
+    mesh.topology.create_connectivity(mesh.topology.dim-1, mesh.topology.dim)
+    boundary_facets = dolfinx.mesh.locate_entities_boundary(mesh, 1, left_boundary)
 
-    backward_compat = _v(dolfinx.__version__) < _v("0.9")
-    if backward_compat:
+
+    el_0 = basix.ufl.element("Lagrange", mesh.basix_cell(), 1)
+    el_1 = basix.ufl.element("Lagrange", mesh.basix_cell(), 2)
+    V = dolfinx.fem.functionspace(mesh, el_0)
+    Q = dolfinx.fem.functionspace(mesh, el_1)
+
+    if auto_split:
+        W = ufl.MixedFunctionSpace(V, Q)
+        v, q = ufl.TestFunctions(W)
+        du, dp = ufl.TrialFunctions(W)
+    else:
         v = ufl.TestFunction(V)
         q = ufl.TestFunction(Q)
         du = ufl.TrialFunction(V)
         dp = ufl.TrialFunction(Q)
-    else:
-        W = ufl.MixedFunctionSpace(V, Q)
-        v, q = ufl.TestFunctions(W)
-        du, dp = ufl.TrialFunctions(W)
 
     # Set nonzero initial guess
     # Choose initial guess acording to the input factor
@@ -41,38 +53,55 @@ def test_NewtonSolver(factor):
     c1 = dolfinx.fem.Constant(mesh, ftype(0.82))
     F0 = ufl.inner(c0 * u**2, v) * ufl.dx - ufl.inner(u_expr, v) * ufl.dx
     F1 = ufl.inner(c1 * p**2, q) * ufl.dx - ufl.inner(p_expr, q) * ufl.dx
-    if backward_compat:
+    if auto_split:
+        F_ = F0 + F1
+        F = list(ufl.extract_blocks(F_))
+        J = ufl.extract_blocks(ufl.derivative(F_, u, du) + ufl.derivative(F_, p, dp))
+    else:
         F = [F0, F1]
         J = [
             [ufl.derivative(F0, u, du), ufl.derivative(F0, p, dp)],
             [ufl.derivative(F1, u, du), ufl.derivative(F1, p, dp)],
         ]
-    else:
-        F_ = F0 + F1
-        F = list(ufl.extract_blocks(F_))
-        J = ufl.extract_blocks(ufl.derivative(F_, u, du) + ufl.derivative(F_, p, dp))
-    petsc_options = {"ksp_type": "preonly", "pc_type": "lu", "pc_factor_mat_solver_type": "mumps"}
-    solver = NewtonSolver(F, J, [u, p], max_iterations=25, petsc_options=petsc_options)
-    solver.solve()
-
+ 
+    # Reference solution
     u_ex = factor * ufl.sqrt(u_expr / c0)
     p_ex = factor * ufl.sqrt(p_expr / c1)
-    err_u = ufl.inner(u_ex - u, u_ex - u) * ufl.dx
-    err_p = ufl.inner(p_ex - p, p_ex - p) * ufl.dx
-    tol = np.finfo(dtype).eps * 1.0e3
-    assert assemble_scalar(err_u) < tol
-    assert assemble_scalar(err_p) < tol
+
+    # Create BC on second space
+    dofs_q = dolfinx.fem.locate_dofs_topological(Q, 
+        mesh.topology.dim-1, boundary_facets)
+    p_bc = dolfinx.fem.Function(Q,dtype=ftype)
+    try:
+        ip = Q.element.interpolation_points()
+    
+    except TypeError:
+        ip = Q.element.interpolation_points
+    p_bc.interpolate(dolfinx.fem.Expression(p_ex, ip))
+    bc_q = dolfinx.fem.dirichletbc(p_bc, dofs_q)
+
+
+
+    petsc_options = {"ksp_type": "preonly", "pc_type": "lu", "pc_factor_mat_solver_type": "mumps"}
+    # solver = NewtonSolver(F, J, [u, p], bcs=[bc_q], max_iterations=25, petsc_options=petsc_options)
+    # solver.solve()
+
+    # err_u = ufl.inner(u_ex - u, u_ex - u) * ufl.dx
+    # err_p = ufl.inner(p_ex - p, p_ex - p) * ufl.dx
+    # tol = np.finfo(dtype).eps * 1.0e3
+    # assert assemble_scalar(err_u) < tol
+    # assert assemble_scalar(err_p) < tol
+
+
 
     # Check consistency with other Newton solver
-    if backward_compat:
-        blocked_solver = dolfinx.nls.NewtonSolver(F, J, [u, p], petsc_options=petsc_options)
-    else:
-        blocked_solver = BlockedNewtonSolver(F, [u, p], J=None, petsc_options=petsc_options)
+    blocked_solver = BlockedNewtonSolver(F, [u, p],bcs=[bc_q], J=None if auto_split else J, petsc_options=petsc_options)
 
     dolfinx.log.set_log_level(dolfinx.log.LogLevel.ERROR)
     u.x.array[:] = factor * 0.1
     p.x.array[:] = factor * 0.02
-    blocked_solver.convergence_criterion = "incremental"
+    blocked_solver.convergence_criterion = "residual"
+    dolfinx.log.set_log_level(dolfinx.log.LogLevel.INFO)
     blocked_solver.solve()
 
     err_u = ufl.inner(u_ex - u, u_ex - u) * ufl.dx

--- a/tests/test_real_functionspace.py
+++ b/tests/test_real_functionspace.py
@@ -194,6 +194,11 @@ def test_singular_poisson(tensor, degree, dtype):
         uh.x.array[: len(x_local[0])] = x_local[0]
         uh.x.scatter_forward()
 
+    b.destroy()
+    x.destroy()
+    A.destroy()
+    ksp.destroy()
+
     error = dolfinx.fem.form(ufl.inner(u_ex - uh, u_ex - uh) * dx, dtype=stype)
 
     e_local = dolfinx.fem.assemble_scalar(error)

--- a/tests/test_real_functionspace.py
+++ b/tests/test_real_functionspace.py
@@ -141,22 +141,28 @@ def test_singular_poisson(tensor, degree, dtype):
     a = dolfinx.fem.form([[a00, a01], [a10, None]], dtype=stype)
     L = dolfinx.fem.form([L0, L1], dtype=stype)
 
+    new_assemble_mode = False
     try:
         A = dolfinx.fem.petsc.assemble_matrix_block(a)
     except AttributeError:
+        new_assemble_mode = True
         A = dolfinx.fem.petsc.assemble_matrix(a, kind="mpi")
     A.assemble()
 
-    try:
-        b = dolfinx.fem.petsc.create_vector_block(L)
-    except AttributeError:
+    if new_assemble_mode:
         b = dolfinx.fem.petsc.create_vector(L, kind="mpi")
+    else:
+        b = dolfinx.fem.petsc.create_vector_block(L)
+
     with b.localForm() as loc:
         loc.set(0)
-    try:
-        dolfinx.fem.petsc.assemble_vector_block(b, L, a, bcs=[])
-    except AttributeError:
+
+    if new_assemble_mode:
         dolfinx.fem.petsc.assemble_vector(b, L)
+        b.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
+        b.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+    else:
+        dolfinx.fem.petsc.assemble_vector_block(b, L, a, bcs=[])
 
     ksp = PETSc.KSP().create(mesh.comm)
     ksp.setOperators(A)
@@ -165,19 +171,28 @@ def test_singular_poisson(tensor, degree, dtype):
     pc.setType("lu")
     pc.setFactorSolverType("mumps")
 
-    try:
-        x = dolfinx.fem.petsc.create_vector_block(L)
-    except AttributeError:
+    if new_assemble_mode:
         x = dolfinx.fem.petsc.create_vector(L, kind="mpi")
+    else:
+        x = dolfinx.fem.petsc.create_vector_block(L)
+
     ksp.solve(b, x)
     x.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+
     uh = dolfinx.fem.Function(V)
-    x_local = dolfinx.cpp.la.petsc.get_local_vectors(
-        x,
-        [(V.dofmap.index_map, V.dofmap.index_map_bs), (R.dofmap.index_map, R.dofmap.index_map_bs)],
-    )
-    uh.x.array[: len(x_local[0])] = x_local[0]
-    uh.x.scatter_forward()
+    rh = dolfinx.fem.Function(R)
+    if new_assemble_mode:
+        dolfinx.fem.petsc.assign(x, [uh, rh])
+    else:
+        x_local = dolfinx.cpp.la.petsc.get_local_vectors(
+            x,
+            [
+                (V.dofmap.index_map, V.dofmap.index_map_bs),
+                (R.dofmap.index_map, R.dofmap.index_map_bs),
+            ],
+        )
+        uh.x.array[: len(x_local[0])] = x_local[0]
+        uh.x.scatter_forward()
 
     error = dolfinx.fem.form(ufl.inner(u_ex - uh, u_ex - uh) * dx, dtype=stype)
 


### PR DESCRIPTION
To handle: https://github.com/FEniCS/dolfinx/pull/3668/
It uncovered: https://github.com/FEniCS/dolfinx/pull/3680, https://github.com/FEniCS/dolfinx/pull/3683

Added handling of the new API to both tests and demos, to illustrate some crucial changes.
Some of it (assigning data to and from blocked spaces), is now way easier with `dolfinx.fem.petsc.assign`.
Arguably, `dolfinx.fem.petsc.assemble_vector_block` has now gotten more complex, as lifting and bcs are no longer included. However, this aligns with the rest of the DOLFINx PETSc API, meaning that non-blocked, blocked and nest operators have to follow the same steps. 