### PR TITLE
Update read_mri_data_to_function

### DIFF
--- a/src/scifem/biomedical.py
+++ b/src/scifem/biomedical.py
@@ -3,6 +3,7 @@ import basix.ufl
 from pathlib import Path
 import numpy as np
 import numpy.typing as npt
+import warnings
 
 
 def apply_mri_transform(
@@ -30,15 +31,14 @@ def apply_mri_transform(
     data = image.get_fdata()
     # Check if the image is in the correct orientation
     orientation = nibabel.aff2axcodes(image.affine)
-    assert orientation == ("R", "A", "S")
+    if orientation != ("R", "A", "S"):
+        warnings.warn(f"Image orientation is {orientation}, expected (R, A, S). ")
 
     # Define mgh_header depending on MRI data types (i.e. nifti or mgz)
     if isinstance(image, nibabel.freesurfer.mghformat.MGHImage):
         mgh_header = image.header
     elif isinstance(image, nibabel.nifti1.Nifti1Image):
         mgh = nibabel.MGHImage(image.dataobj, image.affine)
-        orientation = nibabel.aff2axcodes(mgh.affine)
-        # print("orientation: ", orientation)
         mgh_header = mgh.header
     else:
         raise ValueError(f"Unsupported image type: {type(image)} - Supported types are mgz and nifti")

--- a/src/scifem/biomedical.py
+++ b/src/scifem/biomedical.py
@@ -6,7 +6,7 @@ import numpy.typing as npt
 
 
 def apply_mri_transform(
-    path: Path, coordinates: npt.NDArray[np.floating], use_tkr: bool = False
+    path: Path, coordinates: npt.NDArray[np.floating], vox2ras_transform: npt.NDArray[np.floating] | None = None, use_tkr: bool = False
 ) -> npt.NDArray[np.inexact]:
     """Given a path to a set of MRI voxel data, return the data evaluated at the given coordinates.
 
@@ -16,7 +16,7 @@ def apply_mri_transform(
         use_tkr: If true, use the old freesurfer `tkregister`, see:
             https://www.mail-archive.com/freesurfer@nmr.mgh.harvard.edu/msg69541.html
             for more details. Else use the standard VOX2RAS transform (equivalent to attaching
-            an affine map to a nibabel image.
+            an affine map to a nibabel image.)
 
     Returns:
         The data evaluated at these points.
@@ -28,21 +28,39 @@ def apply_mri_transform(
         raise ImportError("This function requires the nibabel package to be installed")
     image = nibabel.load(path)
     data = image.get_fdata()
-    # This depends on how one uses FreeSurfer
-    if use_tkr:
-        vox2ras = image.header.get_vox2ras_tkr()
-    else:
-        # VOX to ras explanation: https://surfer.nmr.mgh.harvard.edu/ftp/articles/vox2ras.pdf
-        vox2ras = image.header.get_vox2ras()
-    ras2vox = np.linalg.inv(vox2ras)
-    ijk_vectorized = naff.apply_affine(ras2vox, coordinates)
+    # Check if the image is in the correct orientation
+    orientation = nibabel.aff2axcodes(image.affine)
+    assert orientation == ("R", "A", "S")
 
-    # Round indices to nearest integer
+    # Define mgh_header depending on MRI data types (i.e. nifti or mgz)
+    if isinstance(image, nibabel.freesurfer.mghformat.MGHImage):
+        mgh_header = image.header
+    elif isinstance(image, nibabel.nifti1.Nifti1Image):
+        mgh = nibabel.MGHImage(image.dataobj, image.affine)
+        orientation = nibabel.aff2axcodes(mgh.affine)
+        # print("orientation: ", orientation)
+        mgh_header = mgh.header
+    else:
+        raise ValueError(f"Unsupported image type: {type(image)} - Supported types are mgz and nifti")
+
+    # This depends on how one uses FreeSurfer
+    if vox2ras_transform is not None:
+        vox2ras = vox2ras_transform
+    else:
+        if use_tkr:
+            vox2ras = mgh_header.get_vox2ras_tkr()
+        else:
+            # VOX to ras explanation: https://surfer.nmr.mgh.harvard.edu/ftp/articles/vox2ras.pdf
+            vox2ras = mgh_header.get_vox2ras()
+
+    ras2vox = np.linalg.inv(vox2ras)
+
+    ijk_vectorized = naff.apply_affine(ras2vox, coordinates)
     # The file standard assumes that the voxel coordinates refer to the center of each voxel.
     # https://brainder.org/2012/09/23/the-nifti-file-format/
     ijk_rounded = np.rint(ijk_vectorized).astype("int")
-
     assert np.all(ijk_rounded >= 0)
+
     return data[ijk_rounded[:, 0], ijk_rounded[:, 1], ijk_rounded[:, 2]]
 
 
@@ -80,8 +98,10 @@ def read_mri_data_to_function(
     mri_data_path: str | Path,
     mesh: dolfinx.mesh.Mesh,
     cells: npt.NDArray[np.int32] | None = None,
+    vox2ras_transform: npt.NDArray[np.floating] | None = None,
     degree: int = 0,
     dtype: np.inexact = dolfinx.default_scalar_type,
+    use_tkr: bool = False
 ) -> dolfinx.fem.Function:
     """Read in MRI data over a set of cells in the mesh and attach it to an appropriate function.
 
@@ -89,10 +109,17 @@ def read_mri_data_to_function(
         mri_data_path: Path to MRI data
         mesh: The mesh to attach the MRI data to.
         cells: Subset of cells to evaluate the MRI data at. If None, all cells are used.
+        vox2ras_transform: Optional transformation matrix to convert from voxel to ras coordinates.
+            If None, use the transformation matrix from the given MRI data.
         degree: Degree of the (quadrature) function space to attach the MRI data to. Defaults to 0.
             If degree is 0, use a DG-0 space instead of a quadrature space, to simplify
             post-processing.
         dtype: Data type used for input data. Can be used for rounding data.
+        use_tkr: If true, use the old freesurfer `tkregister`, see:
+            https://www.mail-archive.com/freesurfer@nmr.mgh.harvard.edu/msg69541.html
+            for more details. Else use the standard VOX2RAS transform (equivalent to attaching
+            an affine map to a nibabel image.)
+
 
     Raises:
         ValueError: If degree is negative.
@@ -117,7 +144,7 @@ def read_mri_data_to_function(
     dof_positions = Vh.tabulate_dof_coordinates()
     dofmap = Vh.dofmap.list
     dofmap_pos = dofmap[cells].flatten()
-    data = apply_mri_transform(Path(mri_data_path), dof_positions[dofmap_pos])
+    data = apply_mri_transform(Path(mri_data_path), dof_positions[dofmap_pos], vox2ras_transform, use_tkr=use_tkr)
 
     v = dolfinx.fem.Function(Vh)
     v.x.array[dofmap_pos] = data.astype(dtype)

--- a/src/scifem/biomedical.py
+++ b/src/scifem/biomedical.py
@@ -61,9 +61,7 @@ def apply_mri_transform(
             vox2ras = mgh_header.get_vox2ras()
     # Check shape
     if vox2ras.shape != (4, 4):
-        raise ValueError(
-          f"vox2ras transform must be a 4x4 matrix, got shape {vox2ras.shape}"
-        )
+        raise ValueError(f"vox2ras transform must be a 4x4 matrix, got shape {vox2ras.shape}")
 
     ras2vox = np.linalg.inv(vox2ras)
 

--- a/src/scifem/biomedical.py
+++ b/src/scifem/biomedical.py
@@ -17,6 +17,8 @@ def apply_mri_transform(
     Args:
         path: Path to the MRI data, should be a file format supported by nibabel.
         coordinates: Coordinates to evaluate the MRI data at.
+        vox2ras_transform: Optional transformation matrix to convert from voxel to ras coordinates.
+            If None, use the transformation matrix from the given MRI data.
         use_tkr: If true, use the old freesurfer `tkregister`, see:
             https://www.mail-archive.com/freesurfer@nmr.mgh.harvard.edu/msg69541.html
             for more details. Else use the standard VOX2RAS transform (equivalent to attaching
@@ -57,6 +59,11 @@ def apply_mri_transform(
         else:
             # VOX to ras explanation: https://surfer.nmr.mgh.harvard.edu/ftp/articles/vox2ras.pdf
             vox2ras = mgh_header.get_vox2ras()
+    # Check shape
+    if vox2ras.shape != (4, 4):
+        raise ValueError(
+          f"vox2ras transform must be a 4x4 matrix, got shape {vox2ras.shape}"
+        )
 
     ras2vox = np.linalg.inv(vox2ras)
 

--- a/src/scifem/biomedical.py
+++ b/src/scifem/biomedical.py
@@ -79,6 +79,8 @@ def read_mri_data_to_tag(
     mesh: dolfinx.mesh.Mesh,
     edim: int,
     entities: npt.NDArray[np.int32] | None = None,
+    vox2ras_transform: npt.NDArray[np.floating] | None = None,
+    use_tkr: bool = False,
 ) -> dolfinx.mesh.MeshTags:
     """Read in MRI data over a set of entities in the mesh and attach it to a mesh tag.
 
@@ -99,7 +101,7 @@ def read_mri_data_to_tag(
         entities = np.arange(num_entities, dtype=np.int32)
 
     midpoints = dolfinx.mesh.compute_midpoints(mesh, edim, entities)
-    data = apply_mri_transform(Path(mri_data_path), midpoints)
+    data = apply_mri_transform(Path(mri_data_path), midpoints, vox2ras_transform, use_tkr=use_tkr)
     et = dolfinx.mesh.meshtags(mesh, edim, entities, data.astype(np.int32))
     return et
 

--- a/tests/test_read_mri_data.py
+++ b/tests/test_read_mri_data.py
@@ -16,7 +16,9 @@ import basix.ufl
 @pytest.mark.parametrize("mri_data_format", ["nifti", "mgh"])
 @pytest.mark.parametrize("external_affine", [True, False])
 @pytest.mark.parametrize("use_tkr", [False])
-def test_read_mri_data_to_function(degree, M, Nx, Ny, Nz, theta, translation, tmp_path, mri_data_format, external_affine, use_tkr):
+def test_read_mri_data_to_function(
+    degree, M, Nx, Ny, Nz, theta, translation, tmp_path, mri_data_format, external_affine, use_tkr
+):
     nibabel = pytest.importorskip("nibabel")
 
     # Generate rotation and scaling matrix equivalent to a unit cube
@@ -84,9 +86,13 @@ def test_read_mri_data_to_function(degree, M, Nx, Ny, Nz, theta, translation, tm
 
     # # Read data to function
     if external_affine:
-        func = read_mri_data_to_function(filename, mesh, degree=degree, dtype=np.float64, vox2ras_transform=A, use_tkr=use_tkr)
+        func = read_mri_data_to_function(
+            filename, mesh, degree=degree, dtype=np.float64, vox2ras_transform=A, use_tkr=use_tkr
+        )
     else:
-        func = read_mri_data_to_function(filename, mesh, degree=degree, dtype=np.float64, use_tkr=use_tkr)
+        func = read_mri_data_to_function(
+            filename, mesh, degree=degree, dtype=np.float64, use_tkr=use_tkr
+        )
 
     np.testing.assert_allclose(func.x.array, reference_data)
 
@@ -96,7 +102,16 @@ def test_read_mri_data_to_function(degree, M, Nx, Ny, Nz, theta, translation, tm
         # Pick every second cell
         cells = np.arange(num_cells_local, dtype=np.int32)[::2]
         if external_affine:
-            tag = read_mri_data_to_tag(filename, mesh, edim=mesh.topology.dim, entities=cells, vox2ras_transform=A, use_tkr=use_tkr)
+            tag = read_mri_data_to_tag(
+                filename,
+                mesh,
+                edim=mesh.topology.dim,
+                entities=cells,
+                vox2ras_transform=A,
+                use_tkr=use_tkr,
+            )
         else:
-            tag = read_mri_data_to_tag(filename, mesh, edim=mesh.topology.dim, entities=cells, use_tkr=use_tkr)
+            tag = read_mri_data_to_tag(
+                filename, mesh, edim=mesh.topology.dim, entities=cells, use_tkr=use_tkr
+            )
         np.testing.assert_allclose(tag.values, reference_data[::2])

--- a/tests/test_read_mri_data.py
+++ b/tests/test_read_mri_data.py
@@ -13,7 +13,10 @@ import basix.ufl
 @pytest.mark.parametrize("Nz", [9, 17])
 @pytest.mark.parametrize("theta", [np.pi / 3, 0, -np.pi])
 @pytest.mark.parametrize("translation", [np.array([0, 0, 0]), np.array([2.1, 1.3, 0.4])])
-def test_read_mri_data_to_function(degree, M, Nx, Ny, Nz, theta, translation, tmp_path):
+@pytest.mark.parametrize("mri_data_format", ["nifti", "mgh"])
+@pytest.mark.parametrize("external_affine", [True, False])
+@pytest.mark.parametrize("use_tkr", [False])
+def test_read_mri_data_to_function(degree, M, Nx, Ny, Nz, theta, translation, tmp_path, mri_data_format, external_affine, use_tkr):
     nibabel = pytest.importorskip("nibabel")
 
     # Generate rotation and scaling matrix equivalent to a unit cube
@@ -25,14 +28,25 @@ def test_read_mri_data_to_function(degree, M, Nx, Ny, Nz, theta, translation, tm
     # Generate the affine mapping for nibabel
     A = np.append(np.dot(rotation_matrix_3D, scale_matrix), (translation).reshape(3, 1), axis=1)
     A = np.vstack([A, [0, 0, 0, 1]])
+    Id = np.identity(4)
 
     # Write transformed data to file
-    data = np.arange(1, M**3 + 1, dtype=np.float64).reshape(M, M, M)
-    image = nibabel.nifti1.Nifti1Image(data, affine=A)
-
     path = MPI.COMM_WORLD.bcast(tmp_path, root=0)
+    if mri_data_format == "nifti":
+        data = np.arange(1, M**3 + 1, dtype=np.float64).reshape(M, M, M)
+        image = nibabel.nifti1.Nifti1Image(data, affine=Id if external_affine else A)
+    elif mri_data_format == "mgh":
+        data = np.arange(1, M**3 + 1, dtype=np.int32).reshape(M, M, M)
+        image = nibabel.freesurfer.mghformat.MGHImage(data, affine=Id if external_affine else A)
+
+    # Reorient the image to RAS
+    orig_ornt = nibabel.io_orientation(image.affine)
+    targ_ornt = nibabel.orientations.axcodes2ornt("RAS")
+    transform = nibabel.orientations.ornt_transform(orig_ornt, targ_ornt)
+    image = image.as_reoriented(transform)
     filename = path.with_suffix(".mgz")
 
+    # Save the image to file
     if MPI.COMM_WORLD.rank == 0:
         nibabel.save(image, filename)
     MPI.COMM_WORLD.Barrier()
@@ -69,7 +83,10 @@ def test_read_mri_data_to_function(degree, M, Nx, Ny, Nz, theta, translation, tm
     mesh.geometry.x[:] = np.dot(rotation_matrix_3D, shifted_coords.T).T + translation
 
     # # Read data to function
-    func = read_mri_data_to_function(filename, mesh, degree=degree, dtype=np.float64)
+    if external_affine:
+        func = read_mri_data_to_function(filename, mesh, degree=degree, dtype=np.float64, vox2ras_transform=A, use_tkr=use_tkr)
+    else:
+        func = read_mri_data_to_function(filename, mesh, degree=degree, dtype=np.float64, use_tkr=use_tkr)
 
     np.testing.assert_allclose(func.x.array, reference_data)
 
@@ -78,5 +95,8 @@ def test_read_mri_data_to_function(degree, M, Nx, Ny, Nz, theta, translation, tm
         num_cells_local = cell_map.size_local + cell_map.num_ghosts
         # Pick every second cell
         cells = np.arange(num_cells_local, dtype=np.int32)[::2]
-        tag = read_mri_data_to_tag(filename, mesh, edim=mesh.topology.dim, entities=cells)
+        if external_affine:
+            tag = read_mri_data_to_tag(filename, mesh, edim=mesh.topology.dim, entities=cells, vox2ras_transform=A, use_tkr=use_tkr)
+        else:
+            tag = read_mri_data_to_tag(filename, mesh, edim=mesh.topology.dim, entities=cells, use_tkr=use_tkr)
         np.testing.assert_allclose(tag.values, reference_data[::2])


### PR DESCRIPTION
Updates to read_mri_data_to_function :

-  Can read nifti Mri data (.nii / .nii.gz), in addition to mgh images (.mgz)
-  Checks the orientation of the given data (has to be RAS)
-  Can take an optional vox2ras transform, if one needs a specific one (default is affine transform from the given MRI data)
-  Can take `use_tkr`as input (optional), to be used in `apply_mri_transform`