### PR TITLE
Silence ValueError from adios if trying to close file more than once

### DIFF
--- a/src/scifem/xdmf.py
+++ b/src/scifem/xdmf.py
@@ -517,8 +517,12 @@ class BaseXDMFFile(abc.ABC):
 
     def _close_adios(self) -> None:
         logger.debug("Closing ADIOS2 file")
-        self._outfile.Close()
-        assert self._adios.RemoveIO("Point cloud writer")
+        try:
+            self._outfile.Close()
+            assert self._adios.RemoveIO("Point cloud writer")
+        except ValueError:
+            # File is allready closed
+            logger.debug("ADIOS2 file already closed")
 
     def close(self) -> None:
         """Close the XDMF file."""


### PR DESCRIPTION
Seems like https://github.com/scientificcomputing/scifem/pull/103 could trigger multiple calls to the function closing the adios file, see https://scientificcomputing.github.io/scifem/examples/xdmf_point_cloud.html.
So this PR just silence this ValueError.