### PR TITLE
Re-order interior facet tuples for a consistent ("+","-") orientation

### DIFF
--- a/src/scifem/mesh.py
+++ b/src/scifem/mesh.py
@@ -329,11 +329,12 @@ def compute_interface_data(
     """
     Compute interior facet integrals that are consistently ordered according to the `cell_tags`,
     such that the data `(cell0, facet_idx0, cell1, facet_idx1)` is ordered such that
-    `cell_tags[cell0]`<`cell_tags[cell1]`, i.e the cell with the lowest cell marker is considered the
-    "+" restriction".
+    `cell_tags[cell0]`<`cell_tags[cell1]`, i.e the cell with the lowest cell marker
+    is considered the "+" restriction".
 
     Args:
-        cell_tags: MeshTags that must contain an integer marker for all cells adjacent to the `facet_indices`
+        cell_tags: MeshTags that must contain an integer marker for all cells adjacent
+            to the `facet_indices`
         facet_indices: List of facets (local index) that are on the interface.
     Returns:
         The integration data.

--- a/src/scifem/mesh.py
+++ b/src/scifem/mesh.py
@@ -7,6 +7,7 @@ import typing
 import numpy as np
 import numpy.typing as npt
 from typing import Protocol
+from packaging.version import Version
 
 __all__ = [
     "create_entity_markers",
@@ -15,6 +16,7 @@ __all__ = [
     "reverse_mark_entities",
     "extract_submesh",
     "find_interface",
+    "compute_interface_data",
     "compute_subdomain_exterior_facets",
 ]
 
@@ -319,3 +321,38 @@ def compute_subdomain_exterior_facets(
     facet_map = mesh.topology.index_map(mesh.topology.dim - 1)
     # Accumulate ghost facets
     return reverse_mark_entities(facet_map, parent_facets)
+
+
+def compute_interface_data(
+    cell_tags: dolfinx.mesh.MeshTags, facet_indices: npt.NDArray[np.int32]
+) -> npt.NDArray[np.int32]:
+    """
+    Compute interior facet integrals that are consistently ordered according to the `cell_tags`,
+    such that the data `(cell0, facet_idx0, cell1, facet_idx1)` is ordered such that
+    `cell_tags[cell0]`<`cell_tags[cell1]`, i.e the cell with the lowest cell marker is considered the
+    "+" restriction".
+
+    Args:
+        cell_tags: MeshTags that must contain an integer marker for all cells adjacent to the `facet_indices`
+        facet_indices: List of facets (local index) that are on the interface.
+    Returns:
+        The integration data.
+    """
+    # Future compatibilty check
+    integration_args: tuple[int] | tuple
+    if Version("0.10.0") <= Version(dolfinx.__version__):
+        integration_args = ()
+    else:
+        fdim = cell_tags.dim - 1
+        integration_args = (fdim,)
+    idata = dolfinx.cpp.fem.compute_integration_domains(
+        dolfinx.fem.IntegralType.interior_facet,
+        cell_tags.topology,
+        facet_indices,
+        *integration_args,
+    )
+    ordered_idata = idata.reshape(-1, 4).copy()
+    switch = cell_tags.values[ordered_idata[:, 0]] > cell_tags.values[ordered_idata[:, 2]]
+    if True in switch:
+        ordered_idata[switch, :] = ordered_idata[switch][:, [2, 3, 0, 1]]
+    return ordered_idata

--- a/src/scifem/point_source.py
+++ b/src/scifem/point_source.py
@@ -78,9 +78,15 @@ class PointSource:
             )
             self._points = np.array(self._points).reshape(-1, 3)
         elif Version(dolfinx.__version__) >= Version("0.9.0.0"):
-            collision_data = dolfinx.cpp.geometry.determine_point_ownership(
-                mesh._cpp_object, self._input_points, tol
-            )
+            try:
+                collision_data = dolfinx.cpp.geometry.determine_point_ownership(
+                    mesh._cpp_object, self._input_points, tol
+                )
+            except TypeError:
+                collision_data = dolfinx.geometry.determine_point_ownership(
+                    mesh, self._input_points, padding=tol
+                )
+
             self._points = collision_data.dest_points
             self._cells = collision_data.dest_cells
             src_ranks = collision_data.src_owner


### PR DESCRIPTION
Order integration pairs for an interior facet `f`, represented  as `((cell0, local_index0), (cell1, local_index1)) such that the first pair in the tuple is the one which has the lower cell tag.

Also updates `determine_point_ownership` for main branch of DOLFINx post: https://github.com/FEniCS/dolfinx/pull/3927