### PR TITLE
Introduce new function space: Material-Space

### DIFF
--- a/src/scifem/__init__.py
+++ b/src/scifem/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import dolfinx
-import basix
 import numpy as np
 import numpy.typing as npt
 from . import _scifem  # type: ignore
@@ -10,12 +9,14 @@ from .assembly import assemble_scalar, norm
 from .bcs import interpolate_function_onto_facet_dofs
 from . import xdmf
 from .solvers import BlockedNewtonSolver, NewtonSolver
+from .spaces import create_real_functionspace, create_material_space
 from .mesh import create_entity_markers, transfer_meshtags_to_submesh
 from .eval import evaluate_function
 
 __all__ = [
     "PointSource",
     "assemble_scalar",
+    "create_material_space",
     "xdmf",
     "create_real_functionspace",
     "assemble_scalar",
@@ -31,36 +32,6 @@ __all__ = [
     "norm",
     "interpolate_function_onto_facet_dofs",
 ]
-
-
-def create_real_functionspace(
-    mesh: dolfinx.mesh.Mesh, value_shape: tuple[int, ...] = ()
-) -> dolfinx.fem.FunctionSpace:
-    """Create a real function space.
-
-    Args:
-        mesh: The mesh the real space is defined on.
-        value_shape: The shape of the values in the real space.
-
-    Returns:
-        The real valued function space.
-    Note:
-        For scalar elements value shape is ``()``.
-
-    """
-
-    dtype = mesh.geometry.x.dtype
-    ufl_e = basix.ufl.element(
-        "P", mesh.basix_cell(), 0, dtype=dtype, discontinuous=True, shape=value_shape
-    )
-
-    if (dtype := mesh.geometry.x.dtype) == np.float64:
-        cppV = _scifem.create_real_functionspace_float64(mesh._cpp_object, value_shape)
-    elif dtype == np.float32:
-        cppV = _scifem.create_real_functionspace_float32(mesh._cpp_object, value_shape)
-    else:
-        raise ValueError(f"Unsupported dtype: {dtype}")
-    return dolfinx.fem.FunctionSpace(mesh, ufl_e, cppV)
 
 
 def vertex_to_dofmap(V: dolfinx.fem.FunctionSpace) -> npt.NDArray[np.int32]:

--- a/src/scifem/spaces.py
+++ b/src/scifem/spaces.py
@@ -4,6 +4,7 @@ import basix
 import numpy as np
 from . import _scifem  # type: ignore
 from collections.abc import Sequence
+from packaging.version import Version
 
 
 def create_real_functionspace(
@@ -75,7 +76,11 @@ def create_material_space(
     # Create index map describing the distribution of dofs across processes
     ghosts = np.arange(num_ghosts, dtype=np.int64)
     owners = np.full(num_ghosts, ghost_owner_rank, dtype=np.int32)
-    dof_imap = dolfinx.common.IndexMap(mesh.comm, num_dofs, ghosts, owners, tag=321)
+    if Version(dolfinx.__version__) > Version("0.9.0"):
+        imap_kwargs = {"tag": 321}
+    else:
+        imap_kwargs = {}
+    dof_imap = dolfinx.common.IndexMap(mesh.comm, num_dofs, ghosts, owners, **imap_kwargs)
 
     # Create element dof layout (1 dof per cell, based of the DG-0 element)
     value_size = int(np.prod(value_shape))

--- a/src/scifem/spaces.py
+++ b/src/scifem/spaces.py
@@ -58,8 +58,12 @@ def create_material_space(
 
     """
     value_shape = () if value_shape is None else value_shape
-    assert mesh.topology._cpp_object == cell_tag.topology
-    assert cell_tag.dim == mesh.topology.dim
+    if mesh.topology._cpp_object != cell_tag.topology:
+        raise ValueError("Topology of cell tag is not the mesh topology")
+    if cell_tag.dim != mesh.topology.dim:
+        raise ValueError(
+            f"The dimension of the input meshtag is {cell_tag.dim}, expected {mesh.topology.dim}"
+        )
 
     cell_map = mesh.topology.index_map(mesh.topology.dim)
 

--- a/src/scifem/spaces.py
+++ b/src/scifem/spaces.py
@@ -103,10 +103,19 @@ def create_material_space(
     cpp_dofmap = dolfinx.cpp.fem.DofMap(e_layout, dof_imap, index_map_bs, dofmap_adj, bs)
 
     # Create function space
-    cpp_el = dolfinx.cpp.fem.FiniteElement_float64(
-        el.basix_element._e, block_shape=value_shape, symmetric=False
-    )
-    cpp_space = dolfinx.cpp.fem.FunctionSpace_float64(mesh._cpp_object, cpp_el, cpp_dofmap)
+    try:
+        cpp_el = dolfinx.cpp.fem.FiniteElement_float64(
+            el.basix_element._e, block_shape=value_shape, symmetric=False
+        )
+        cpp_space = dolfinx.cpp.fem.FunctionSpace_float64(mesh._cpp_object, cpp_el, cpp_dofmap)
+    except TypeError:
+        cpp_el = dolfinx.cpp.fem.FiniteElement_float64(
+            el.basix_element._e, block_size=bs, symmetric=False
+        )
+        cpp_space = dolfinx.cpp.fem.FunctionSpace_float64(
+            mesh._cpp_object, cpp_el, cpp_dofmap, value_shape=value_shape
+        )
+
     _el = basix.ufl.element("P", mesh.basix_cell(), 0, shape=value_shape, discontinuous=True)
     V = dolfinx.fem.FunctionSpace(mesh, _el, cpp_space)
     return V

--- a/src/scifem/spaces.py
+++ b/src/scifem/spaces.py
@@ -40,7 +40,7 @@ def create_material_space(
     mesh: dolfinx.mesh.Mesh,
     cell_tag: dolfinx.mesh.MeshTags,
     tags: Sequence[int | np.int32 | np.int64],
-    value_shape: tuple[int] = None,
+    value_shape: tuple[()] | tuple[int | tuple[int]] | None = None,
 ) -> dolfinx.fem.FunctionSpace:
     """Create a material function space.
 

--- a/src/scifem/spaces.py
+++ b/src/scifem/spaces.py
@@ -1,0 +1,107 @@
+from mpi4py import MPI
+import dolfinx
+import basix
+import numpy as np
+from . import _scifem  # type: ignore
+from collections.abc import Sequence
+
+
+def create_real_functionspace(
+    mesh: dolfinx.mesh.Mesh, value_shape: tuple[int, ...] = ()
+) -> dolfinx.fem.FunctionSpace:
+    """Create a real function space.
+
+    Args:
+        mesh: The mesh the real space is defined on.
+        value_shape: The shape of the values in the real space.
+
+    Returns:
+        The real valued function space.
+    Note:
+        For scalar elements value shape is ``()``.
+
+    """
+
+    dtype = mesh.geometry.x.dtype
+    ufl_e = basix.ufl.element(
+        "P", mesh.basix_cell(), 0, dtype=dtype, discontinuous=True, shape=value_shape
+    )
+
+    if (dtype := mesh.geometry.x.dtype) == np.float64:
+        cppV = _scifem.create_real_functionspace_float64(mesh._cpp_object, value_shape)
+    elif dtype == np.float32:
+        cppV = _scifem.create_real_functionspace_float32(mesh._cpp_object, value_shape)
+    else:
+        raise ValueError(f"Unsupported dtype: {dtype}")
+    return dolfinx.fem.FunctionSpace(mesh, ufl_e, cppV)
+
+
+def create_material_space(
+    mesh: dolfinx.mesh.Mesh,
+    cell_tag: dolfinx.mesh.MeshTags,
+    tags: Sequence[int | np.int32 | np.int64],
+    value_shape: tuple[int] = None,
+) -> dolfinx.fem.FunctionSpace:
+    """Create a material function space.
+
+    Args:
+        mesh: The mesh the material space is defined on.
+        cell_tag: The mesh tags defining the materials on this process.
+        tags: The material tags that should be represented in the function space.
+
+    Returns:
+        The material function space.
+    Note:
+        The material function space is a discontinuous, piecewise constant
+        function space with one degree of freedom per unique cell tag value.
+
+    """
+    value_shape = () if value_shape is None else value_shape
+    assert mesh.topology._cpp_object == cell_tag.topology
+    assert cell_tag.dim == mesh.topology.dim
+
+    cell_map = mesh.topology.index_map(mesh.topology.dim)
+
+    # Determine the owner of the material degrees of freedom.
+    # It will be the process that owns the cell with global index 0
+    is_owner = cell_map.local_range[0] == 0 and cell_map.size_local > 0
+
+    # Determine number of dofs and ghosts on each process
+    el = basix.ufl.element("P", mesh.basix_cell(), 0, shape=(), discontinuous=True)
+    num_dofs = len(tags) * is_owner
+    num_ghosts = len(tags) * (not is_owner)
+    (_, ghost_owner_rank) = mesh.comm.allreduce((is_owner, mesh.comm.rank), op=MPI.MAXLOC)
+
+    # Create index map describing the distribution of dofs across processes
+    ghosts = np.arange(num_ghosts, dtype=np.int64)
+    owners = np.full(num_ghosts, ghost_owner_rank, dtype=np.int32)
+    dof_imap = dolfinx.common.IndexMap(mesh.comm, num_dofs, ghosts, owners, tag=321)
+
+    # Create element dof layout (1 dof per cell, based of the DG-0 element)
+    value_size = int(np.prod(value_shape))
+    index_map_bs = value_size
+    bs = value_size
+
+    e_layout = dolfinx.cpp.fem.ElementDofLayout(
+        value_size, el.entity_dofs, el.entity_closure_dofs, [], []
+    )
+
+    # Create dofmap mapping local dofs to position in `tags` input.
+    adj_flattened = np.zeros_like(cell_tag.values)
+    for i, tag in enumerate(tags):
+        adj_flattened[cell_tag.find(tag)] = i
+
+    # Create dofmap
+    dofmap_adj = dolfinx.cpp.graph.AdjacencyList_int32(
+        adj_flattened, np.arange(len(cell_tag.values) + 1, dtype=np.int32)
+    )
+    cpp_dofmap = dolfinx.cpp.fem.DofMap(e_layout, dof_imap, index_map_bs, dofmap_adj, bs)
+
+    # Create function space
+    cpp_el = dolfinx.cpp.fem.FiniteElement_float64(
+        el.basix_element._e, block_shape=value_shape, symmetric=False
+    )
+    cpp_space = dolfinx.cpp.fem.FunctionSpace_float64(mesh._cpp_object, cpp_el, cpp_dofmap)
+    _el = basix.ufl.element("P", mesh.basix_cell(), 0, shape=value_shape, discontinuous=True)
+    V = dolfinx.fem.FunctionSpace(mesh, _el, cpp_space)
+    return V

--- a/tests/test_material_space.py
+++ b/tests/test_material_space.py
@@ -1,0 +1,82 @@
+from mpi4py import MPI
+import dolfinx
+from scifem import create_material_space
+import pytest
+import numpy as np
+import ufl
+
+
+@pytest.mark.parametrize("value_shape", [(), (3,), (3, 2)])
+@pytest.mark.parametrize(
+    "cell_type", ["interval", "triangle", "quadrilateral", "hexahedron", "tetrahedron"]
+)
+def test_material_space(value_shape: tuple[int], cell_type: str):
+    cell = dolfinx.mesh.to_type(cell_type)
+    tdim = dolfinx.mesh.cell_dim(cell)
+    if tdim == 1:
+        mesh = dolfinx.mesh.create_unit_interval(
+            MPI.COMM_WORLD, 20, ghost_mode=dolfinx.mesh.GhostMode.shared_facet
+        )
+    elif tdim == 2:
+        mesh = dolfinx.mesh.create_unit_square(
+            MPI.COMM_WORLD, 20, 20, ghost_mode=dolfinx.mesh.GhostMode.shared_facet, cell_type=cell
+        )
+    elif tdim == 3:
+        mesh = dolfinx.mesh.create_unit_cube(
+            MPI.COMM_WORLD,
+            12,
+            12,
+            8,
+            ghost_mode=dolfinx.mesh.GhostMode.shared_facet,
+            cell_type=cell,
+        )
+    else:
+        raise ValueError(f"Unsupported {cell_type=}")
+
+    def ball(x, tol=1e-8):
+        conditions = []
+        for i in range(tdim):
+            conditions.append((x[i] - 0.5) ** 2 <= 0.2**2 + tol)
+        return np.logical_and.reduce(conditions)
+
+    def top(x, tol=1e-8):
+        return x[tdim - 1] >= 0.7 - tol
+
+    cell_map = mesh.topology.index_map(mesh.topology.dim)
+    all_cells = np.arange(cell_map.size_local + cell_map.num_ghosts, dtype=np.int32)
+    tags = [1, 5, 3]
+    values = np.full_like(all_cells, tags[0])
+    values[dolfinx.mesh.locate_entities(mesh, mesh.topology.dim, ball)] = tags[1]
+    values[dolfinx.mesh.locate_entities(mesh, mesh.topology.dim, top)] = tags[2]
+    ct = dolfinx.mesh.meshtags(mesh, mesh.topology.dim, all_cells, values)
+
+    V = create_material_space(mesh, ct, tags, value_shape=value_shape)
+    assert V.dofmap.index_map.size_global == len(tags)
+    assert V.dofmap.index_map.size_local + V.dofmap.index_map.num_ghosts == len(tags)
+    assert (V.dofmap.index_map.size_local == 0) or (V.dofmap.index_map.num_ghosts == 0)
+    value_size = int(np.prod(value_shape))
+    assert V.dofmap.index_map_bs == value_size
+    assert V.dofmap.bs == value_size
+    array = V.dofmap.list
+    for i, tag in enumerate(tags):
+        np.testing.assert_allclose(array[ct.indices[ct.values == tag]].flatten(), i)
+
+    # Check that we can assign values to the function for each region, and that it gives a sensible result
+    bs = V.dofmap.bs
+    for i, tag in enumerate(tags):
+        vals = np.arange(i + 1, i + 1 + bs, dtype=np.float64)
+        f = dolfinx.fem.Function(V)
+        f.x.array[i * bs : (i + 1) * bs] = vals
+
+        form = dolfinx.fem.form(ufl.inner(f, f) * ufl.dx)
+        local_integral = dolfinx.fem.assemble_scalar(form)
+        integral = mesh.comm.allreduce(local_integral, op=MPI.SUM)
+        dx_restricted = ufl.Measure("dx", domain=mesh, subdomain_data=ct, subdomain_id=tag)
+        if value_shape == ():
+            f_ex = vals[0]
+        else:
+            f_ex = ufl.as_tensor(vals.reshape(value_shape))
+        form_ex = dolfinx.fem.form(ufl.inner(f_ex, f_ex) * dx_restricted)
+        local_integral_ex = dolfinx.fem.assemble_scalar(form_ex)
+        integral_ex = mesh.comm.allreduce(local_integral_ex, op=MPI.SUM)
+        np.testing.assert_allclose(integral, integral_ex)

--- a/tests/test_material_space.py
+++ b/tests/test_material_space.py
@@ -61,7 +61,8 @@ def test_material_space(value_shape: tuple[int], cell_type: str):
     for i, tag in enumerate(tags):
         np.testing.assert_allclose(array[ct.indices[ct.values == tag]].flatten(), i)
 
-    # Check that we can assign values to the function for each region, and that it gives a sensible result
+    # Check that we can assign values to the function for each region, and that it gives
+    # a sensible result
     bs = V.dofmap.bs
     for i, tag in enumerate(tags):
         vals = np.arange(i + 1, i + 1 + bs, dtype=np.float64)


### PR DESCRIPTION
# Rationale
Currently, to represent piecewise constant materials in DOLFINx, one has to use a `DG-0` space where one assigns a single value to a subset of cells.
This is a waste of memory, and makes optimization of material parameters tricky, as they should move as a single integer through differentiation.
An alternative is to use the "Real"-function space introduced in scifem, which can be multiplied by an indicator function, or summed over a set of restricted integration measures to get the correct representation across the domains.
The latter approach can result in over-complicated forms (huge compilation time) and unreadable code for cases where one has more than 2-3 spaces.

# Solution
Introduce a new constructor `create_material_space`, that takes in the mesh, a mesh-tag tag marks each cell (including ghosts) with a value from the input list `tags`.
A function space with as many unblocked dofs as there are unique values in `tags` are created (spaces can be vectors or tensors).

For a scalar space, the user only assign a value `v_i` to `u.x.array[i]` that indicate that all cells tagged with `tags[i]` has this value.
For vector/tensor spaces, the dofs are blocked such that, a tensor `v_i` with shape (NxM) is assigned to `u.x.array[i*N*M:(i+1)*N*M]` for the cells tagged with `tags[i]`.