### PR TITLE
Make a more safe handling of assigning owning process for real space dofs

### DIFF
--- a/tests/test_real_functionspace.py
+++ b/tests/test_real_functionspace.py
@@ -42,6 +42,7 @@ def test_real_function_space_mass(L, H, cell_type, dtype):
         assert V.dofmap.index_map.size_local == 0
         assert V.dofmap.index_map.num_ghosts == 1
 
+
 @pytest.mark.parametrize("dtype", [np.float64, np.float32])
 @pytest.mark.parametrize(
     "cell_type", [dolfinx.mesh.CellType.tetrahedron, dolfinx.mesh.CellType.hexahedron]

--- a/tests/test_real_functionspace.py
+++ b/tests/test_real_functionspace.py
@@ -36,7 +36,11 @@ def test_real_function_space_mass(L, H, cell_type, dtype):
         assert len(A.data) == 1
         if cell_map.local_range[0] == 0:
             assert np.isclose(A.data[0], L * H, atol=tol)
-
+    else:
+        assert len(A.data) == 0
+        assert len(V.dofmap.list.flatten()) == 0
+        assert V.dofmap.index_map.size_local == 0
+        assert V.dofmap.index_map.num_ghosts == 1
 
 @pytest.mark.parametrize("dtype", [np.float64, np.float32])
 @pytest.mark.parametrize(

--- a/tests/test_real_functionspace.py
+++ b/tests/test_real_functionspace.py
@@ -31,10 +31,11 @@ def test_real_function_space_mass(L, H, cell_type, dtype):
     A = dolfinx.fem.assemble_matrix(dolfinx.fem.form(a, dtype=dtype), bcs=[])
     A.scatter_reverse()
     tol = 100 * np.finfo(dtype).eps
-
-    assert len(A.data) == 1
-    if MPI.COMM_WORLD.rank == 0:
-        assert np.isclose(A.data[0], L * H, atol=tol)
+    cell_map = mesh.topology.index_map(mesh.topology.dim)
+    if cell_map.size_local + cell_map.num_ghosts > 0:
+        assert len(A.data) == 1
+        if cell_map.local_range[0] == 0:
+            assert np.isclose(A.data[0], L * H, atol=tol)
 
 
 @pytest.mark.parametrize("dtype", [np.float64, np.float32])


### PR DESCRIPTION
# Rationale
For very small meshes, it might be that the partitioner assigns no cells to rank 0, which would lead to an "invalid" function space wrt. DOLFINx operations.

# Fix
Decide owning process through a reduction operator on which process that owns the first cell in the mesh.
Similar to what is done in #136 