### PR TITLE
Speed up real space tests

### DIFF
--- a/tests/test_real_functionspace.py
+++ b/tests/test_real_functionspace.py
@@ -89,7 +89,7 @@ def test_real_function_space_vector(cell_type, dtype):
 @pytest.mark.parametrize("tensor", [0, 1, 2])
 @pytest.mark.parametrize("degree", range(1, 5))
 def test_singular_poisson(tensor, degree, dtype):
-    M = 25
+    M = 9
 
     rtype, stype = dtype
     mesh = dolfinx.mesh.create_unit_square(


### PR DESCRIPTION
Reduce size of grid, as we have a tensor space with six components for up to a fourth order polynomial.