### PR TITLE
Deactivate complex interpolation matrix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "scifem"
-version = "0.13.0"
+version = "0.13.1"
 description = "Scientific tools for finite element methods"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -138,7 +138,7 @@ tag = true
 sign_tags = false
 tag_name = "v{new_version}"
 tag_message = "Bump version: {current_version} → {new_version}"
-current_version = "0.13.0"
+current_version = "0.13.1"
 
 
 [[tool.bumpversion.files]]

--- a/src/scifem/interpolation.py
+++ b/src/scifem/interpolation.py
@@ -32,6 +32,9 @@ def prepare_interpolation_data(
     Returns:
         Interpolation data per cell, as an numpy array.
     """
+    if np.issubdtype(dolfinx.default_scalar_type, np.complexfloating):
+        raise NotImplementedError("No complex support")
+
     try:
         q_points = Q.element.interpolation_points()
     except TypeError:

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -6,6 +6,9 @@ import ufl
 import numpy as np
 
 
+@pytest.mark.skipif(
+    np.issubdtype(dolfinx.default_scalar_type, np.complexfloating), reason="No complex support"
+)
 @pytest.mark.parametrize(
     "cell_type",
     [
@@ -60,6 +63,9 @@ def test_interpolation_matrix(use_petsc, cell_type, degree):
     np.testing.assert_allclose(q.x.array, q_ref.x.array, rtol=1e-12, atol=1e-13)
 
 
+@pytest.mark.skipif(
+    np.issubdtype(dolfinx.default_scalar_type, np.complexfloating), reason="No complex support"
+)
 @pytest.mark.skipif(
     not hasattr(dolfinx.fem, "discrete_gradient"),
     reason="Cannot verify without discrete gradient from DOLFINx",
@@ -136,6 +142,9 @@ def test_discrete_gradient(degree, use_petsc, cell_type):
     np.testing.assert_allclose(w.x.array, w_ref.x.array, rtol=1e-11, atol=1e-12)
 
 
+@pytest.mark.skipif(
+    np.issubdtype(dolfinx.default_scalar_type, np.complexfloating), reason="No complex support"
+)
 @pytest.mark.skipif(
     not hasattr(dolfinx.fem, "discrete_curl"),
     reason="Cannot verify without discrete curl from DOLFINx",


### PR DESCRIPTION
Can't find a way to do this nicely in Python atm.