### PR TITLE
Add tolerance to point source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "scifem"
-version = "0.14.0"
+version = "0.15.0"
 description = "Scientific tools for finite element methods"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -138,7 +138,7 @@ tag = true
 sign_tags = false
 tag_name = "v{new_version}"
 tag_message = "Bump version: {current_version} → {new_version}"
-current_version = "0.14.0"
+current_version = "0.15.0"
 
 
 [[tool.bumpversion.files]]


### PR DESCRIPTION
Attempt to solve #166. Now the user can set the point collision tolerance, increasing it from the rather stringent 1e-14 that it was hard-coded to for standard DOLFINx installations.