### PR TITLE
Skip tests for xdmf if HDF5 version is 2.0

### DIFF
--- a/tests/test_xdmf.py
+++ b/tests/test_xdmf.py
@@ -18,6 +18,12 @@ except ImportError:
     hash5py = False
 
 
+if h5py.h5.HDF5_VERSION_COMPILED_AGAINST == (2, 0, 0):
+    pytest.skip(
+        "h5py and adios2 built against HDF5 2.0.0 does not work properly", allow_module_level=True
+    )
+
+
 stype = PETSc.ScalarType
 rtype = PETSc.RealType
 _dolfinx_version = Version(dolfinx.__version__)


### PR DESCRIPTION
Tests are currently failing because the latest version of h5py does not support version 2.0 of HDF5. A fix is [merged into main](https://github.com/h5py/h5py/pull/2750) but we are still waiting for a new release. 
Tests are also failing for adios2, and an issue has been filed [here](https://github.com/ornladios/ADIOS2/issues/4806)