### PR TITLE
Add closest point projection based on Projected Gradient with a Simplex projection algorithm

### DIFF
--- a/src/scifem.cpp
+++ b/src/scifem.cpp
@@ -166,10 +166,7 @@ inline void projection(const std::array<T, tdim>& x,
     simplex_projection(x, projected);
   else
     for (std::size_t i = 0; i < tdim; ++i)
-    {
-      projected[i] = std::max(x[i], T(0));
-      projected[i] = std::min(projected[i], T(1));
-    }
+      projected[i] = std::clamp(x[i], T(0.0), T(1.0));
 }
 
 } // namespace impl

--- a/src/scifem.cpp
+++ b/src/scifem.cpp
@@ -178,7 +178,7 @@ template <typename T, std::size_t tdim, bool is_simplex, std::size_t gdim>
 std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
     const dolfinx::mesh::Mesh<T>& mesh, std::span<const std::int32_t> cells,
     std::span<const T> points, T tol_x, T tol_dist, T tol_grad,
-    std::size_t max_iter, std::size_t max_ls_iter)
+    std::size_t max_iter, std::size_t max_ls_iter, std::size_t num_threads)
 {
   constexpr T eps = std::numeric_limits<T>::epsilon();
   constexpr T roundoff_tol = 100 * eps;
@@ -192,212 +192,234 @@ std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
   T midpoint_divider = (is_simplex) ? 1.0 : 0.0;
   std::ranges::fill(initial_guess, 1.0 / ((T)tdim + midpoint_divider));
 
-  std::array<T, tdim> projected;
-
   const std::array<std::size_t, 4> dtab_shape = cmap.tabulate_shape(1, 1);
   const std::array<std::size_t, 4> tab_shape = cmap.tabulate_shape(0, 1);
   const std::size_t basis_data_size
       = std::reduce(tab_shape.begin(), tab_shape.end(), 1, std::multiplies{});
-  // Use single buffer for 0th and 1st order derivatives, as we only need one at
-  // a time
-  std::vector<T> dphi_b(
-      std::reduce(dtab_shape.begin(), dtab_shape.end(), 1, std::multiplies{}));
-  md::mdspan<const T, md::dextents<std::size_t, 4>> phi_full(dphi_b.data(),
-                                                             dtab_shape);
-  auto phi = md::submdspan(phi_full, 0, md::full_extent, md::full_extent, 0);
-  auto dphi
-      = md::submdspan(phi_full, std::pair(1, tdim + 1), 0, md::full_extent, 0);
 
-  std::array<T, tdim> x_k;
-  std::array<T, tdim> x_old;
-  std::array<T, gdim> diff;
-  std::array<T, gdim * tdim> J_buffer;
-  std::array<T, tdim> gradient;
-  std::array<T, tdim> x_new_prev;
-  std::array<T, tdim> x_new;
-  std::array<T, tdim> x_k_tmp;
-  std::array<T, gdim> target_point;
-
-  md::mdspan<T, md::extents<std::size_t, gdim, tdim>> J(J_buffer.data(), gdim,
-                                                        tdim);
-
-  std::array<T, gdim> X_phys_buffer;
-  md::mdspan<T, md::extents<std::size_t, 1, gdim>> surface_point(
-      X_phys_buffer.data(), 1, gdim);
-
-  // Extract data to compute cell geometry
   md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>> x_dofmap
       = mesh.geometry().dofmap(0);
   std::span<const T> x = mesh.geometry().x();
-  std::vector<T> cdofs(3 * x_dofmap.extent(1));
-  md::mdspan<const T, md::dextents<std::size_t, 2>> cell_geometry(
-      cdofs.data(), x_dofmap.extent(1), gdim);
 
-  constexpr T sigma = 0.1;
-  constexpr T beta = 0.5;
-
-  for (std::size_t i = 0; i < cells.size(); ++i)
+  auto compute_chunk = [&](std::size_t c0, std::size_t c1)
   {
-    // Pack cell geometry into mdspan for push_forward
-    auto x_dofs = md::submdspan(x_dofmap, cells[i], md::full_extent);
-    for (std::size_t k = 0; k < x_dofs.size(); ++k)
-      std::copy_n(x.data() + (3 * x_dofs[k]), gdim,
-                  std::next(cdofs.begin(), gdim * k));
+    // Use single buffer for 0th and 1st order derivatives, as we only need one
+    // at a time
+    std::vector<T> dphi_b(std::reduce(dtab_shape.begin(), dtab_shape.end(), 1,
+                                      std::multiplies{}));
+    md::mdspan<const T, md::dextents<std::size_t, 4>> phi_full(dphi_b.data(),
+                                                               dtab_shape);
+    auto phi = md::submdspan(phi_full, 0, md::full_extent, md::full_extent, 0);
+    auto dphi = md::submdspan(phi_full, std::pair(1, tdim + 1), 0,
+                              md::full_extent, 0);
 
-    std::copy(points.data() + (3 * i), points.data() + (3 * i) + gdim,
-              target_point.begin());
+    std::array<T, tdim> x_k;
+    std::array<T, tdim> x_old;
+    std::array<T, gdim> diff;
+    std::array<T, gdim * tdim> J_buffer;
+    std::array<T, tdim> gradient;
+    std::array<T, tdim> x_new_prev;
+    std::array<T, tdim> x_new;
+    std::array<T, tdim> x_k_tmp;
+    std::array<T, gdim> target_point;
 
-    // Update Initial guess
-    std::ranges::copy(initial_guess, x_k.begin());
-    for (std::size_t k = 0; k < max_iter; k++)
+    md::mdspan<T, md::extents<std::size_t, gdim, tdim>> J(J_buffer.data(), gdim,
+                                                          tdim);
+
+    std::array<T, gdim> X_phys_buffer;
+    md::mdspan<T, md::extents<std::size_t, 1, gdim>> surface_point(
+        X_phys_buffer.data(), 1, gdim);
+
+    // Extract data to compute cell geometry
+    std::vector<T> cdofs(3 * x_dofmap.extent(1));
+    md::mdspan<const T, md::dextents<std::size_t, 2>> cell_geometry(
+        cdofs.data(), x_dofmap.extent(1), gdim);
+
+    constexpr T sigma = 0.1;
+    constexpr T beta = 0.5;
+
+    for (std::size_t i = c0; i < c1; ++i)
     {
-      for (std::size_t l = 0; l < tdim; ++l)
-        x_old[l] = x_k[l];
+      // Pack cell geometry into mdspan for push_forward
+      auto x_dofs = md::submdspan(x_dofmap, cells[i], md::full_extent);
+      for (std::size_t k = 0; k < x_dofs.size(); ++k)
+        std::copy_n(x.data() + (3 * x_dofs[k]), gdim,
+                    std::next(cdofs.begin(), gdim * k));
 
-      // Tabulate basis function and gradient at current point
-      std::ranges::fill(dphi_b, 0);
-      cmap.tabulate(1, std::span(x_k.data(), tdim), {1, tdim}, dphi_b);
+      std::copy(points.data() + (3 * i), points.data() + (3 * i) + gdim,
+                target_point.begin());
 
-      // Push forward to physicalspace
-      dolfinx::fem::CoordinateElement<T>::push_forward(surface_point,
-                                                       cell_geometry, phi);
-
-      // Compute objective function (squared distance to point)/2
-      T current_dist_sq = 0;
-      for (std::size_t d = 0; d < gdim; ++d)
+      // Update Initial guess
+      std::ranges::copy(initial_guess, x_k.begin());
+      for (std::size_t k = 0; k < max_iter; k++)
       {
-        diff[d] = X_phys_buffer[d] - target_point[d];
-        current_dist_sq += diff[d] * diff[d];
-      }
-      current_dist_sq *= T(0.5);
+        for (std::size_t l = 0; l < tdim; ++l)
+          x_old[l] = x_k[l];
 
-      // Compute Jacobian (tangent vectors)
-      for (std::size_t l = 0; l < tdim * gdim; l++)
-        J_buffer[l] = 0;
-      dolfinx::fem::CoordinateElement<T>::compute_jacobian(dphi, cell_geometry,
-                                                           J);
+        // Tabulate basis function and gradient at current point
+        std::ranges::fill(dphi_b, 0);
+        cmap.tabulate(1, std::span(x_k.data(), tdim), {1, tdim}, dphi_b);
 
-      // Compute tangents (J^T diff)
-      for (std::size_t m = 0; m < tdim; ++m)
-        gradient[m] = 0;
-      for (std::size_t l = 0; l < gdim; ++l)
-        for (std::size_t m = 0; m < tdim; ++m)
-          gradient[m] += J(l, m) * diff[l];
-
-      // Check for convergence in gradient norm, scaled by Jacobian to account
-      // for stretching of the reference space
-      T jac_norm = 0;
-      for (std::size_t l = 0; l < tdim * gdim; l++)
-        jac_norm += J_buffer[l] * J_buffer[l];
-      T scaled_tol_grad = tol_grad * std::max(jac_norm, T(1));
-      T g_squared = 0;
-      for (std::size_t l = 0; l < tdim; ++l)
-        g_squared += gradient[l] * gradient[l];
-      if (g_squared < scaled_tol_grad)
-      {
-        break;
-      }
-
-      // Goldstein-Polyak-Levitin Projected Line Search
-      // Bertsekas (1976) Eq. (14) - Armijo Rule along the Projection Arc
-      for (std::size_t l = 0; l < tdim; ++l)
-        x_new_prev[l] = -1;
-      bool target_reached = false;
-      T alpha = 1.0;
-      for (std::size_t ls_iter = 0; ls_iter < max_ls_iter; ++ls_iter)
-      {
-        // Take projected gradient step
-        // Compute new step xk - alpha * g and project back to domain
-        for (std::size_t l = 0; l < tdim; l++)
-          x_k_tmp[l] = x_k[l] - alpha * gradient[l];
-        impl::projection<T, tdim, is_simplex>(x_k_tmp, x_new);
-
-        // The projection is pinned to the boundary, terminate search
-        T local_diff = 0;
-        for (std::size_t l = 0; l < tdim; l++)
-          local_diff += (x_new[l] - x_new_prev[l]) * (x_new[l] - x_new_prev[l]);
-        if (local_diff < eps * eps)
-          break;
-        for (std::size_t l = 0; l < tdim; l++)
-          x_new_prev[l] = x_new[l];
-
-        // Evaluate distance at new point
-        std::ranges::fill(std::span(dphi_b.data(), basis_data_size), T(0));
-        cmap.tabulate(0, std::span(x_new.data(), tdim), {1, tdim},
-                      std::span(dphi_b.data(), basis_data_size));
-
-        // Push forward to physical space
+        // Push forward to physicalspace
         dolfinx::fem::CoordinateElement<T>::push_forward(surface_point,
                                                          cell_geometry, phi);
 
         // Compute objective function (squared distance to point)/2
-        T new_sq_dist = 0;
+        T current_dist_sq = 0;
+        for (std::size_t d = 0; d < gdim; ++d)
+        {
+          diff[d] = X_phys_buffer[d] - target_point[d];
+          current_dist_sq += diff[d] * diff[d];
+        }
+        current_dist_sq *= T(0.5);
+
+        // Compute Jacobian (tangent vectors)
+        for (std::size_t l = 0; l < tdim * gdim; l++)
+          J_buffer[l] = 0;
+        dolfinx::fem::CoordinateElement<T>::compute_jacobian(dphi,
+                                                             cell_geometry, J);
+
+        // Compute tangents (J^T diff)
+        for (std::size_t m = 0; m < tdim; ++m)
+          gradient[m] = 0;
         for (std::size_t l = 0; l < gdim; ++l)
-        {
-          diff[l] = X_phys_buffer[l] - target_point[l];
-          new_sq_dist += diff[l] * diff[l];
-        }
-        new_sq_dist *= 0.5;
+          for (std::size_t m = 0; m < tdim; ++m)
+            gradient[m] += J(l, m) * diff[l];
 
-        // If we are close enough to the targetpoint we terminate the
-        // linesearch, even if the Armijo condition is not satisfied, to avoid
-        // unnecessary iterations close to the target point.
-        if (new_sq_dist < 0.5 * tol_dist * tol_dist)
-        {
-          target_reached = true;
-          break;
-        }
-
-        // Bertsekas Eq. (14) condition:
-        // f(x_new) <= f(x_k) + sigma * grad_f(x_k)^T * (x_new - x_k)
-        // Note: g is grad_f(x_k)
-        // Size of step after projecting back to boundary
-        T grad_dot_step = 0;
-        for (std::size_t d = 0; d < tdim; ++d)
-          grad_dot_step += gradient[d] * (x_new[d] - x_k[d]);
-        if (new_sq_dist
-            <= current_dist_sq + sigma * grad_dot_step + roundoff_tol)
+        // Check for convergence in gradient norm, scaled by Jacobian to account
+        // for stretching of the reference space
+        T jac_norm = 0;
+        for (std::size_t l = 0; l < tdim * gdim; l++)
+          jac_norm += J_buffer[l] * J_buffer[l];
+        T scaled_tol_grad = tol_grad * std::max(jac_norm, T(1));
+        T g_squared = 0;
+        for (std::size_t l = 0; l < tdim; ++l)
+          g_squared += gradient[l] * gradient[l];
+        if (g_squared < scaled_tol_grad)
         {
           break;
         }
 
-        alpha *= beta;
-        if (ls_iter == max_ls_iter - 1)
+        // Goldstein-Polyak-Levitin Projected Line Search
+        // Bertsekas (1976) Eq. (14) - Armijo Rule along the Projection Arc
+        for (std::size_t l = 0; l < tdim; ++l)
+          x_new_prev[l] = -1;
+        bool target_reached = false;
+        T alpha = 1.0;
+        for (std::size_t ls_iter = 0; ls_iter < max_ls_iter; ++ls_iter)
         {
-          std::cout << "Line search failed to find a suitable step after "
-                    << max_ls_iter << " iterations." << std::endl;
+          // Take projected gradient step
+          // Compute new step xk - alpha * g and project back to domain
+          for (std::size_t l = 0; l < tdim; l++)
+            x_k_tmp[l] = x_k[l] - alpha * gradient[l];
+          impl::projection<T, tdim, is_simplex>(x_k_tmp, x_new);
+
+          // The projection is pinned to the boundary, terminate search
+          T local_diff = 0;
+          for (std::size_t l = 0; l < tdim; l++)
+            local_diff
+                += (x_new[l] - x_new_prev[l]) * (x_new[l] - x_new_prev[l]);
+          if (local_diff < eps * eps)
+            break;
+          for (std::size_t l = 0; l < tdim; l++)
+            x_new_prev[l] = x_new[l];
+
+          // Evaluate distance at new point
+          std::ranges::fill(std::span(dphi_b.data(), basis_data_size), T(0));
+          cmap.tabulate(0, std::span(x_new.data(), tdim), {1, tdim},
+                        std::span(dphi_b.data(), basis_data_size));
+
+          // Push forward to physical space
+          dolfinx::fem::CoordinateElement<T>::push_forward(surface_point,
+                                                           cell_geometry, phi);
+
+          // Compute objective function (squared distance to point)/2
+          T new_sq_dist = 0;
+          for (std::size_t l = 0; l < gdim; ++l)
+          {
+            diff[l] = X_phys_buffer[l] - target_point[l];
+            new_sq_dist += diff[l] * diff[l];
+          }
+          new_sq_dist *= 0.5;
+
+          // If we are close enough to the targetpoint we terminate the
+          // linesearch, even if the Armijo condition is not satisfied, to avoid
+          // unnecessary iterations close to the target point.
+          if (new_sq_dist < 0.5 * tol_dist * tol_dist)
+          {
+            target_reached = true;
+            break;
+          }
+
+          // Bertsekas Eq. (14) condition:
+          // f(x_new) <= f(x_k) + sigma * grad_f(x_k)^T * (x_new - x_k)
+          // Note: g is grad_f(x_k)
+          // Size of step after projecting back to boundary
+          T grad_dot_step = 0;
+          for (std::size_t d = 0; d < tdim; ++d)
+            grad_dot_step += gradient[d] * (x_new[d] - x_k[d]);
+          if (new_sq_dist
+              <= current_dist_sq + sigma * grad_dot_step + roundoff_tol)
+          {
+            break;
+          }
+
+          alpha *= beta;
+          if (ls_iter == max_ls_iter - 1)
+          {
+            std::cout << "Line search failed to find a suitable step after "
+                      << max_ls_iter << " iterations." << std::endl;
+          }
+        }
+
+        std::ranges::copy(x_new, x_k.begin());
+        if (target_reached)
+          break;
+
+        // Check if Newton iteration has converged
+        T x_diff_sq = 0;
+        for (std::size_t l = 0; l < tdim; l++)
+          x_diff_sq += (x_k[l] - x_old[l]) * (x_k[l] - x_old[l]);
+        if (x_diff_sq < tol_x * tol_x)
+          break;
+
+        if (k == max_iter - 1)
+        {
+          throw std::runtime_error("Newton iteration failed to converge after "
+                                   + std::to_string(max_iter) + " iterations.");
         }
       }
+      // Push forward to physicalspace for closest point
+      std::ranges::fill(std::span(dphi_b.data(), basis_data_size), T(0));
+      cmap.tabulate(0, std::span(x_k.data(), tdim), {1, tdim},
+                    std::span(dphi_b.data(), basis_data_size));
+      dolfinx::fem::CoordinateElement<T>::push_forward(surface_point,
+                                                       cell_geometry, phi);
 
-      std::ranges::copy(x_new, x_k.begin());
-      if (target_reached)
-        break;
-
-      // Check if Newton iteration has converged
-      T x_diff_sq = 0;
-      for (std::size_t l = 0; l < tdim; l++)
-        x_diff_sq += (x_k[l] - x_old[l]) * (x_k[l] - x_old[l]);
-      if (x_diff_sq < tol_x * tol_x)
-        break;
-
-      if (k == max_iter - 1)
-      {
-        throw std::runtime_error("Newton iteration failed to converge after "
-                                 + std::to_string(max_iter) + " iterations.");
-      }
+      std::copy_n(X_phys_buffer.data(), gdim,
+                  std::next(closest_points.begin(), 3 * i));
+      std::copy_n(x_k.begin(), tdim,
+                  std::next(reference_points.begin(), tdim * i));
     }
-    // Push forward to physicalspace for closest point
-    std::ranges::fill(std::span(dphi_b.data(), basis_data_size), T(0));
-    cmap.tabulate(0, std::span(x_k.data(), tdim), {1, tdim},
-                  std::span(dphi_b.data(), basis_data_size));
-    dolfinx::fem::CoordinateElement<T>::push_forward(surface_point,
-                                                     cell_geometry, phi);
-    std::copy_n(X_phys_buffer.data(), gdim,
-                std::next(closest_points.begin(), 3 * i));
-    std::copy_n(x_k.begin(), tdim,
-                std::next(reference_points.begin(), tdim * i));
-  }
+  };
 
+  size_t total_cells = cells.size();
+  num_threads = std::max<size_t>(1, std::min(num_threads, total_cells));
+  // --- THREAD EXECUTION ---
+  if (num_threads <= 1)
+  {
+    compute_chunk(0, total_cells);
+  }
+  else
+  {
+    std::vector<std::jthread> threads;
+    threads.reserve(num_threads);
+    for (size_t i = 0; i < num_threads; ++i)
+    {
+      auto [c0, c1] = dolfinx::MPI::local_range(i, total_cells, num_threads);
+      threads.emplace_back(compute_chunk, c0, c1);
+    }
+  }
   return {std::move(closest_points), std::move(reference_points)};
 }
 
@@ -738,7 +760,7 @@ void declare_closest_point(nanobind::module_& m, std::string type)
          nanobind::ndarray<const T, nanobind::ndim<2>, nanobind::c_contig>
              points,
          T tol_x, T tol_dist, T tol_grad, std::size_t max_iter,
-         std::size_t max_ls_iter)
+         std::size_t max_ls_iter, std::size_t num_threads)
       {
         std::size_t tdim
             = dolfinx::mesh::cell_dim(mesh.topology()->cell_type());
@@ -760,7 +782,7 @@ void declare_closest_point(nanobind::module_& m, std::string type)
                     mesh,
                     std::span<const std::int32_t>(cells.data(), cells.size()),
                     std::span<const T>(points.data(), points.size()), tol_x,
-                    tol_dist, tol_grad, max_iter, max_ls_iter);
+                    tol_dist, tol_grad, max_iter, max_ls_iter, num_threads);
             return std::make_tuple(
                 as_nbarray(closest_point, {cells.size(), 3}),
                 as_nbarray(closest_ref, {cells.size(), tdim}));
@@ -772,7 +794,7 @@ void declare_closest_point(nanobind::module_& m, std::string type)
                     mesh,
                     std::span<const std::int32_t>(cells.data(), cells.size()),
                     std::span<const T>(points.data(), points.size()), tol_x,
-                    tol_dist, tol_grad, max_iter, max_ls_iter);
+                    tol_dist, tol_grad, max_iter, max_ls_iter, num_threads);
             return std::make_tuple(
                 as_nbarray(closest_point, {cells.size(), 3}),
                 as_nbarray(closest_ref, {cells.size(), tdim}));
@@ -784,7 +806,7 @@ void declare_closest_point(nanobind::module_& m, std::string type)
                     mesh,
                     std::span<const std::int32_t>(cells.data(), cells.size()),
                     std::span<const T>(points.data(), points.size()), tol_x,
-                    tol_dist, tol_grad, max_iter, max_ls_iter);
+                    tol_dist, tol_grad, max_iter, max_ls_iter, num_threads);
             return std::make_tuple(
                 as_nbarray(closest_point, {cells.size(), 3}),
                 as_nbarray(closest_ref, {cells.size(), tdim}));
@@ -807,7 +829,7 @@ void declare_closest_point(nanobind::module_& m, std::string type)
                       mesh,
                       std::span<const std::int32_t>(cells.data(), cells.size()),
                       std::span<const T>(points.data(), points.size()), tol_x,
-                      tol_dist, tol_grad, max_iter, max_ls_iter);
+                      tol_dist, tol_grad, max_iter, max_ls_iter, num_threads);
               return std::make_tuple(
                   as_nbarray(closest_point, {cells.size(), 3}),
                   as_nbarray(closest_ref, {cells.size(), tdim}));
@@ -819,7 +841,7 @@ void declare_closest_point(nanobind::module_& m, std::string type)
                       mesh,
                       std::span<const std::int32_t>(cells.data(), cells.size()),
                       std::span<const T>(points.data(), points.size()), tol_x,
-                      tol_dist, tol_grad, max_iter, max_ls_iter);
+                      tol_dist, tol_grad, max_iter, max_ls_iter, num_threads);
               return std::make_tuple(
                   as_nbarray(closest_point, {cells.size(), 3}),
                   as_nbarray(closest_ref, {cells.size(), tdim}));
@@ -839,7 +861,7 @@ void declare_closest_point(nanobind::module_& m, std::string type)
                       mesh,
                       std::span<const std::int32_t>(cells.data(), cells.size()),
                       std::span<const T>(points.data(), points.size()), tol_x,
-                      tol_dist, tol_grad, max_iter, max_ls_iter);
+                      tol_dist, tol_grad, max_iter, max_ls_iter, num_threads);
               return std::make_tuple(
                   as_nbarray(closest_point, {cells.size(), 3}),
                   as_nbarray(closest_ref, {cells.size(), tdim}));
@@ -851,7 +873,7 @@ void declare_closest_point(nanobind::module_& m, std::string type)
                       mesh,
                       std::span<const std::int32_t>(cells.data(), cells.size()),
                       std::span<const T>(points.data(), points.size()), tol_x,
-                      tol_dist, tol_grad, max_iter, max_ls_iter);
+                      tol_dist, tol_grad, max_iter, max_ls_iter, num_threads);
               return std::make_tuple(
                   as_nbarray(closest_point, {cells.size(), 3}),
                   as_nbarray(closest_ref, {cells.size(), tdim}));
@@ -870,7 +892,7 @@ void declare_closest_point(nanobind::module_& m, std::string type)
                     mesh,
                     std::span<const std::int32_t>(cells.data(), cells.size()),
                     std::span<const T>(points.data(), points.size()), tol_x,
-                    tol_dist, tol_grad, max_iter, max_ls_iter);
+                    tol_dist, tol_grad, max_iter, max_ls_iter, num_threads);
             return std::make_tuple(
                 as_nbarray(closest_point, {cells.size(), 3}),
                 as_nbarray(closest_ref, {cells.size(), tdim}));
@@ -882,7 +904,7 @@ void declare_closest_point(nanobind::module_& m, std::string type)
                     mesh,
                     std::span<const std::int32_t>(cells.data(), cells.size()),
                     std::span<const T>(points.data(), points.size()), tol_x,
-                    tol_dist, tol_grad, max_iter, max_ls_iter);
+                    tol_dist, tol_grad, max_iter, max_ls_iter, num_threads);
             return std::make_tuple(
                 as_nbarray(closest_point, {cells.size(), 3}),
                 as_nbarray(closest_ref, {cells.size(), tdim}));
@@ -896,7 +918,7 @@ void declare_closest_point(nanobind::module_& m, std::string type)
       nanobind::arg("mesh"), nanobind::arg("cells"), nanobind::arg("points"),
       nanobind::arg("tol_x"), nanobind::arg("tol_dist"),
       nanobind::arg("tol_grad"), nanobind::arg("max_iter"),
-      nanobind::arg("max_ls_iter"),
+      nanobind::arg("max_ls_iter"), nanobind::arg("num_threads"),
       "Compute the closest points on the mesh to a set of input points, and "
       "return the closest points and their reference coordinates.");
 }

--- a/src/scifem.cpp
+++ b/src/scifem.cpp
@@ -237,9 +237,9 @@ std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
   {
     // Pack cell geometry into mdspan for push_forward
     auto x_dofs = md::submdspan(x_dofmap, cells[i], md::full_extent);
-    for (std::size_t i = 0; i < x_dofs.size(); ++i)
-      std::copy_n(x.data() + (3 * x_dofs[i]), gdim,
-                  std::next(cdofs.begin(), gdim * i));
+    for (std::size_t k = 0; k < x_dofs.size(); ++k)
+      std::copy_n(x.data() + (3 * x_dofs[k]), gdim,
+                  std::next(cdofs.begin(), gdim * k));
 
     std::span<const T> target_point(points.data() + 3 * i, 3);
 
@@ -325,8 +325,8 @@ std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
                                [](T xki, T xni) { return xni - xki; });
         // Evaluate distance at new point
 
-        std::ranges::fill(dphi_b, basis_data_size);
-        cmap.tabulate(0, std::span(x_k.data(), tdim), {1, tdim},
+        std::ranges::fill(std::span(dphi_b.data(), basis_data_size), T(0));
+        cmap.tabulate(0, std::span(x_new.data(), tdim), {1, tdim},
                       std::span(dphi_b.data(), basis_data_size));
 
         // Push forward to physical space
@@ -355,7 +355,7 @@ std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
         // Note: g is grad_f(x_k)
         if (new_sq_dist
             <= current_dist_sq
-                   - sigma
+                   + sigma
                          * std::inner_product(gradient.begin(), gradient.end(),
                                               actual_step.begin(), T(0))
                    + roundoff_tol)
@@ -387,17 +387,17 @@ std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
         throw std::runtime_error("Newton iteration failed to converge after "
                                  + std::to_string(max_iter) + " iterations.");
       }
-
-      // Push forward to physicalspace for closest point
-      cmap.tabulate(0, std::span(x_k.data(), tdim), {1, tdim},
-                    std::span(dphi_b.data(), basis_data_size));
-      dolfinx::fem::CoordinateElement<T>::push_forward(surface_point,
-                                                       cell_geometry, phi);
-      std::copy_n(X_phys_buffer.data(), gdim,
-                  std::next(closest_points.begin(), 3 * i));
-      std::copy_n(x_k.begin(), tdim,
-                  std::next(reference_points.begin(), tdim * i));
     }
+    // Push forward to physicalspace for closest point
+    std::ranges::fill(std::span(dphi_b.data(), basis_data_size), T(0));
+    cmap.tabulate(0, std::span(x_k.data(), tdim), {1, tdim},
+                  std::span(dphi_b.data(), basis_data_size));
+    dolfinx::fem::CoordinateElement<T>::push_forward(surface_point,
+                                                     cell_geometry, phi);
+    std::copy_n(X_phys_buffer.data(), gdim,
+                std::next(closest_points.begin(), 3 * i));
+    std::copy_n(x_k.begin(), tdim,
+                std::next(reference_points.begin(), tdim * i));
   }
 
   return {std::move(closest_points), std::move(reference_points)};

--- a/src/scifem.cpp
+++ b/src/scifem.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2024-2026 Jørgen S. Dokken and Henrik N.T. Finsberg
 // C++ wrappers for SCIFEM
 
+#include <algorithm>
 #include <basix/finite-element.h>
 #include <basix/mdspan.hpp>
 #include <dolfinx/common/IndexMap.h>
@@ -13,6 +14,7 @@
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/MeshTags.h>
 #include <dolfinx/mesh/cell_types.h>
+#include <iostream>
 #include <memory>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
@@ -20,6 +22,8 @@
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/vector.h>
+#include <numeric>
+#include <thread>
 
 namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
 

--- a/src/scifem.cpp
+++ b/src/scifem.cpp
@@ -206,7 +206,7 @@ std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
                                                              dtab_shape);
   auto phi = md::submdspan(phi_full, 0, md::full_extent, md::full_extent, 0);
   auto dphi
-      = md::submdspan(phi_full, std::pair(1, gdim + 1), 0, md::full_extent, 0);
+      = md::submdspan(phi_full, std::pair(1, tdim + 1), 0, md::full_extent, 0);
 
   std::array<T, tdim> x_k;
   std::array<T, tdim> x_old;

--- a/src/scifem.cpp
+++ b/src/scifem.cpp
@@ -371,11 +371,11 @@ std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
           alpha *= beta;
           if (ls_iter == max_ls_iter - 1)
           {
-            std::string out_msg
-                = "Line search failed to find a suitable step after {} "
-                  "iterations. "
-                  "Current dist: {}, grad_dot_step: {}, alpha: {}";
-            out_msg = std::format(out_msg, new_sq_dist, grad_dot_step, alpha);
+            std::string out_msg = std::format(
+                "Line search failed to find a suitable step after {} "
+                "iterations. "
+                "Current dist: {}, grad_dot_step: {}, alpha: {}",
+                max_ls_iter, new_sq_dist, grad_dot_step, alpha);
             std::cout << out_msg << std::endl;
           }
         }

--- a/src/scifem.cpp
+++ b/src/scifem.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Jørgen S. Dokken and Henrik N.T. Finsberg
+// Copyright (C) 2024-2026 Jørgen S. Dokken and Henrik N.T. Finsberg
 // C++ wrappers for SCIFEM
 
 #include <basix/finite-element.h>
@@ -11,6 +11,7 @@
 #include <dolfinx/la/Vector.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/MeshTags.h>
+#include <dolfinx/mesh/cell_types.h>
 #include <memory>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
@@ -54,8 +55,176 @@ auto as_nbarrayp(std::pair<V, std::array<std::size_t, U>>&& x)
 
 } // namespace
 
+namespace impl
+{
+template <typename T>
+inline void sort_array_3_descending(std::array<T, 3>& arr)
+{
+  // If the second element is larger, swap it to the front
+  if (arr[1] > arr[0])
+    std::swap(arr[0], arr[1]);
+
+  // If the third element is larger, swap it up
+  if (arr[2] > arr[1])
+    std::swap(arr[1], arr[2]);
+
+  // One final check between the first two elements
+  if (arr[1] > arr[0])
+    std::swap(arr[0], arr[1]);
+}
+
+template <typename T>
+inline void sort_array_2_descending(std::array<T, 2>& arr)
+{
+  if (arr[1] > arr[0])
+    std::swap(arr[0], arr[1]);
+}
+
+template <typename T, std::size_t tdim>
+inline void simplex_projection(const std::array<T, tdim>& x,
+                               std::array<T, tdim>& projected)
+{
+  std::array<T, tdim> u;
+  std::transform(x.begin(), x.end(), u.begin(),
+                 [](auto xi) { return std::max(xi, T(0)); });
+  T sum = std::accumulate(u.begin(), u.end(), T(0));
+  if (sum <= 1.0)
+  {
+    if constexpr (tdim == 2)
+    {
+      projected[0] = u[0];
+      projected[1] = u[1];
+      return;
+    }
+    else if constexpr (tdim == 3)
+    {
+      projected[0] = u[0];
+      projected[1] = u[1];
+      projected[2] = u[2];
+      return;
+    }
+    else
+    {
+      static_assert(tdim == 2 || tdim == 3, "Unsupported dimension");
+    }
+  }
+  std::array<T, tdim> x_sorted = x;
+  std::array<T, tdim> cumsum;
+  std::array<bool, tdim> Ks;
+  std::size_t K;
+  if constexpr (tdim == 2)
+  {
+    impl::sort_array_2_descending(x_sorted);
+    cumsum[0] = x_sorted[0];
+    cumsum[1] = x_sorted[0] + x_sorted[1];
+    Ks[0] = x_sorted[0] > (cumsum[0] - 1.0);
+    Ks[1] = x_sorted[1] * 2 > (cumsum[1] - 1.0);
+    if (Ks[1])
+      K = 2;
+    else if (Ks[0])
+      K = 1;
+    else
+      throw std::runtime_error("Unexpected condition in simplex projection.");
+  }
+  else if constexpr (tdim == 3)
+  {
+    impl::sort_array_3_descending(x_sorted);
+    cumsum[0] = x_sorted[0];
+    cumsum[1] = x_sorted[0] + x_sorted[1];
+    cumsum[2] = x_sorted[0] + x_sorted[1] + x_sorted[2];
+    Ks[0] = x_sorted[0] > (cumsum[0] - 1.0);
+    Ks[1] = x_sorted[1] * 2 > (cumsum[1] - 1.0);
+    Ks[2] = x_sorted[2] * 3 > (cumsum[2] - 1.0);
+    if (Ks[2])
+      K = 3;
+    else if (Ks[1])
+      K = 2;
+    else if (Ks[0])
+      K = 1;
+    else
+      throw std::runtime_error("Unexpected condition in simplex projection.");
+  }
+  else
+  {
+    static_assert(tdim == 2 || tdim == 3, "Unsupported dimension");
+  }
+  T tau = (cumsum[K - 1] - 1.0) / (K);
+  for (std::size_t i = 0; i < tdim; ++i)
+    projected[i] = std::max(x[i] - tau, T(0));
+};
+
+template <typename T, std::size_t tdim, bool is_simplex>
+inline void projection(const std::array<T, tdim>& x,
+                       std::array<T, tdim>& projected)
+{
+  if constexpr (is_simplex)
+    simplex_projection(x, projected);
+  else
+    for (std::size_t i = 0; i < tdim; ++i)
+    {
+      projected[i] = std::max(x[i], T(0));
+      projected[i] = std::min(projected[i], T(1));
+    }
+}
+
+} // namespace impl
+
 namespace scifem
 {
+
+template <typename T, std::size_t tdim, bool is_simplex>
+std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
+    const dolfinx::mesh::Mesh<T>& mesh, std::span<const std::int32_t> cells,
+    std::span<const T> points, T tol_x, T tol_dist, T tol_grad,
+    std::size_t max_iter, std::size_t max_ls_iter)
+{
+  constexpr T roundoff_tol = 10 * std::numeric_limits<T>::epsilon();
+
+  basix::FiniteElement e = basix::create_element<T>(
+      basix::element::family::P,
+      dolfinx::mesh::cell_type_to_basix_type(mesh.topology()->cell_type()),
+      mesh.geometry().cmap().degree(), mesh.geometry().cmap().variant(),
+      basix::element::dpc_variant::unset, false);
+
+  assert(mesh.geometry().cmap().hash() == e.hash());
+  std::vector<T> closest_points(cells.size());
+  assert(cells.size() == points.size() / 3);
+  std::vector<T> reference_points(cells.size() * mesh.topology()->dim());
+
+  std::array<T, tdim> initial_guess = {1. / T(tdim)};
+
+  std::function<void(const std::array<T, tdim>&, std::array<T, tdim>&)> project;
+
+  std::array<T, tdim> projected;
+
+  impl::projection<T, tdim, is_simplex>(initial_guess, projected);
+
+  std::array<T, tdim> x_k;
+  for (std::size_t i = 0; i < cells.size(); ++i)
+  {
+    std::span<const T> point(points.data() + 3 * i, 3);
+
+    // Update Initial guess
+    std::ranges::copy(initial_guess, x_k.begin());
+    // for (std::size_t k = 0; k < max_iter; ++k)
+    // {
+    //   // 1. Projection
+    //   impl::projection<T, tdim, is_simplex>(x_k, projected);
+
+    //   // 2. Compute closest point and gradient
+    //   T dist;
+    //   std::array<T, 3> g;
+    //   std::tie(closest_points[i], dist, g) = e.evaluate_closest_point(
+    //       cells[i], projected.data(), point.data());
+
+    //   // Check convergence
+    //   if (dist < tol_dist || dist < roundoff_tol)
+    //     break;
+  }
+
+  return {std::move(closest_points), std::move(reference_points)};
+}
+
 template <typename T>
 dolfinx::fem::FunctionSpace<T>
 create_real_functionspace(std::shared_ptr<const dolfinx::mesh::Mesh<T>> mesh,
@@ -244,8 +413,8 @@ transfer_meshtags_to_submesh(
 
   // Accumulate global indices across processes
   dolfinx::la::Vector<std::int64_t> index_mapper(parent_entity_map, 1);
-  index_mapper.set(-1);
-  std::span<std::int64_t> indices = index_mapper.mutable_array();
+  std::ranges::fill(index_mapper.array(), -1);
+  std::span<std::int64_t> indices = index_mapper.array();
   for (std::size_t i = 0; i < global_tag_indices.size(); ++i)
     indices[tag_indices[i]] = global_tag_indices[i];
   index_mapper.scatter_rev([](std::int32_t a, std::int32_t b)
@@ -254,16 +423,16 @@ transfer_meshtags_to_submesh(
 
   // Map tag values in a similar way (Allowing negative values)
   dolfinx::la::Vector<T> values_mapper(parent_entity_map, 1);
-  values_mapper.set(std::numeric_limits<T>::min());
-  std::span<T> values = values_mapper.mutable_array();
+  std::ranges::fill(values_mapper.array(), std::numeric_limits<T>::min());
+  std::span<T> values = values_mapper.array();
   std::span<const T> tag_values = tags.values();
   for (std::size_t i = 0; i < tag_values.size(); ++i)
     values[tag_indices[i]] = tag_values[i];
   values_mapper.scatter_rev([](T a, T b) { return std::max<T>(a, b); });
   values_mapper.scatter_fwd();
 
-  // For each entity in the tag, find all cells of the submesh connected to this
-  // entity. Global to local returns -1 if not on process.
+  // For each entity in the tag, find all cells of the submesh connected to
+  // this entity. Global to local returns -1 if not on process.
   std::vector<std::int32_t> local_indices(indices.size());
   parent_entity_map->global_to_local(indices, local_indices);
   std::span<const T> parent_values = values_mapper.array();
@@ -380,6 +549,77 @@ void declare_meshtag_operators(nanobind::module_& m, std::string type)
       nanobind::arg("vertex_map"), nanobind::arg("cell_map"));
 }
 
+template <typename T>
+void declare_closest_point(nanobind::module_& m, std::string type)
+{
+  std::string pyfunc_name = "closest_point_projection_" + type;
+  m.def(
+      pyfunc_name.c_str(),
+      [](const dolfinx::mesh::Mesh<T>& mesh,
+         nanobind::ndarray<const std::int32_t, nanobind::ndim<1>,
+                           nanobind::c_contig>
+             cells,
+         nanobind::ndarray<const T, nanobind::ndim<2>, nanobind::c_contig>
+             points,
+         T tol_x, T tol_dist, T tol_grad, std::size_t max_iter,
+         std::size_t max_ls_iter)
+      {
+        std::size_t tdim
+            = dolfinx::mesh::cell_dim(mesh.topology()->cell_type());
+        bool is_simplex
+            = (mesh.topology()->cell_type() == dolfinx::mesh::CellType::triangle
+               || mesh.topology()->cell_type()
+                      == dolfinx::mesh::CellType::tetrahedron);
+        switch (tdim)
+        {
+        case 1:
+          return scifem::closest_point_projection<T, 1, false>(
+              mesh, std::span<const std::int32_t>(cells.data(), cells.size()),
+              std::span<const T>(points.data(), points.size()), tol_x, tol_dist,
+              tol_grad, max_iter, max_ls_iter);
+        case 2:
+        {
+          if (is_simplex)
+          {
+            return scifem::closest_point_projection<T, 2, true>(
+                mesh, std::span<const std::int32_t>(cells.data(), cells.size()),
+                std::span<const T>(points.data(), points.size()), tol_x,
+
+                tol_dist, tol_grad, max_iter, max_ls_iter);
+          }
+          else
+          {
+            return scifem::closest_point_projection<T, 2, false>(
+                mesh, std::span<const std::int32_t>(cells.data(), cells.size()),
+                std::span<const T>(points.data(), points.size()), tol_x,
+                tol_dist, tol_grad, max_iter, max_ls_iter);
+          }
+        }
+        case 3:
+        {
+          if (is_simplex)
+            return scifem::closest_point_projection<T, 3, true>(
+                mesh, std::span<const std::int32_t>(cells.data(), cells.size()),
+                std::span<const T>(points.data(), points.size()), tol_x,
+                tol_dist, tol_grad, max_iter, max_ls_iter);
+          else
+            return scifem::closest_point_projection<T, 3, false>(
+                mesh, std::span<const std::int32_t>(cells.data(), cells.size()),
+                std::span<const T>(points.data(), points.size()), tol_x,
+                tol_dist, tol_grad, max_iter, max_ls_iter);
+        }
+        default:
+          throw std::runtime_error("Unsupported cell dimension");
+        }
+      },
+      nanobind::arg("mesh"), nanobind::arg("cells"), nanobind::arg("points"),
+      nanobind::arg("tol_x"), nanobind::arg("tol_dist"),
+      nanobind::arg("tol_grad"), nanobind::arg("max_iter"),
+      nanobind::arg("max_ls_iter"),
+      "Compute the closest points on the mesh to a set of input points, and "
+      "return the closest points and their reference coordinates.");
+}
+
 } // namespace scifem_wrapper
 
 NB_MODULE(_scifem, m)
@@ -387,4 +627,6 @@ NB_MODULE(_scifem, m)
   scifem_wrapper::declare_real_function_space<double>(m, "float64");
   scifem_wrapper::declare_real_function_space<float>(m, "float32");
   scifem_wrapper::declare_meshtag_operators<std::int32_t>(m, "int32");
+  scifem_wrapper::declare_closest_point<double>(m, "float64");
+  scifem_wrapper::declare_closest_point<float>(m, "float32");
 }

--- a/src/scifem.cpp
+++ b/src/scifem.cpp
@@ -2,6 +2,7 @@
 // C++ wrappers for SCIFEM
 
 #include <basix/finite-element.h>
+#include <basix/mdspan.hpp>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/version.h>
 #include <dolfinx/fem/DofMap.h>
@@ -15,9 +16,12 @@
 #include <memory>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
+#include <nanobind/stl/pair.h>
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/vector.h>
+
+namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
 
 namespace
 {
@@ -57,6 +61,7 @@ auto as_nbarrayp(std::pair<V, std::array<std::size_t, U>>&& x)
 
 namespace impl
 {
+
 template <typename T>
 inline void sort_array_3_descending(std::array<T, 3>& arr)
 {
@@ -85,8 +90,8 @@ inline void simplex_projection(const std::array<T, tdim>& x,
                                std::array<T, tdim>& projected)
 {
   std::array<T, tdim> u;
-  std::transform(x.begin(), x.end(), u.begin(),
-                 [](auto xi) { return std::max(xi, T(0)); });
+  std::ranges::transform(x, u.begin(),
+                         [](auto xi) { return std::max(xi, T(0)); });
   T sum = std::accumulate(u.begin(), u.end(), T(0));
   if (sum <= 1.0)
   {
@@ -172,54 +177,227 @@ inline void projection(const std::array<T, tdim>& x,
 namespace scifem
 {
 
-template <typename T, std::size_t tdim, bool is_simplex>
+template <typename T, std::size_t tdim, bool is_simplex, std::size_t gdim>
 std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
     const dolfinx::mesh::Mesh<T>& mesh, std::span<const std::int32_t> cells,
     std::span<const T> points, T tol_x, T tol_dist, T tol_grad,
     std::size_t max_iter, std::size_t max_ls_iter)
 {
-  constexpr T roundoff_tol = 10 * std::numeric_limits<T>::epsilon();
+  constexpr T eps = std::numeric_limits<T>::epsilon();
+  constexpr T roundoff_tol = 100 * eps;
 
-  basix::FiniteElement e = basix::create_element<T>(
-      basix::element::family::P,
-      dolfinx::mesh::cell_type_to_basix_type(mesh.topology()->cell_type()),
-      mesh.geometry().cmap().degree(), mesh.geometry().cmap().variant(),
-      basix::element::dpc_variant::unset, false);
-
-  assert(mesh.geometry().cmap().hash() == e.hash());
-  std::vector<T> closest_points(cells.size());
+  const dolfinx::fem::CoordinateElement<T>& cmap = mesh.geometry().cmap();
+  std::vector<T> closest_points(3 * cells.size());
   assert(cells.size() == points.size() / 3);
-  std::vector<T> reference_points(cells.size() * mesh.topology()->dim());
+  std::vector<T> reference_points(cells.size() * tdim);
 
-  std::array<T, tdim> initial_guess = {1. / T(tdim)};
-
-  std::function<void(const std::array<T, tdim>&, std::array<T, tdim>&)> project;
+  std::array<T, tdim> initial_guess;
+  T midpoint_divider = (is_simplex) ? 1.0 : 0.0;
+  std::ranges::fill(initial_guess, 1.0 / ((T)tdim + midpoint_divider));
 
   std::array<T, tdim> projected;
 
-  impl::projection<T, tdim, is_simplex>(initial_guess, projected);
+  const std::array<std::size_t, 4> dtab_shape = cmap.tabulate_shape(1, 1);
+  const std::array<std::size_t, 4> tab_shape = cmap.tabulate_shape(0, 1);
+  const std::size_t basis_data_size
+      = std::reduce(tab_shape.begin(), tab_shape.end(), 1, std::multiplies{});
+  // Use single buffer for 0th and 1st order derivatives, as we only need one at
+  // a time
+  std::vector<T> dphi_b(
+      std::reduce(dtab_shape.begin(), dtab_shape.end(), 1, std::multiplies{}));
+  md::mdspan<const T, md::dextents<std::size_t, 4>> phi_full(dphi_b.data(),
+                                                             dtab_shape);
+  auto phi = md::submdspan(phi_full, 0, md::full_extent, md::full_extent, 0);
+  auto dphi
+      = md::submdspan(phi_full, std::pair(1, gdim + 1), 0, md::full_extent, 0);
 
   std::array<T, tdim> x_k;
+  std::array<T, tdim> x_old;
+  std::array<T, gdim> diff;
+  std::array<T, gdim * tdim> J_buffer;
+  std::array<T, tdim> gradient;
+  std::array<T, tdim> x_new_prev;
+  std::array<T, tdim> x_new;
+  md::mdspan<T, md::extents<std::size_t, gdim, tdim>> J(J_buffer.data(), gdim,
+                                                        tdim);
+
+  std::array<T, gdim> X_phys_buffer;
+  md::mdspan<T, md::extents<std::size_t, 1, gdim>> surface_point(
+      X_phys_buffer.data(), 1, gdim);
+
+  // Extract data to compute cell geometry
+  md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>> x_dofmap
+      = mesh.geometry().dofmap(0);
+  std::span<const T> x = mesh.geometry().x();
+  std::vector<T> cdofs(3 * x_dofmap.extent(1));
+  md::mdspan<const T, md::dextents<std::size_t, 2>> cell_geometry(
+      cdofs.data(), x_dofmap.extent(1), gdim);
+
   for (std::size_t i = 0; i < cells.size(); ++i)
   {
-    std::span<const T> point(points.data() + 3 * i, 3);
+    // Pack cell geometry into mdspan for push_forward
+    auto x_dofs = md::submdspan(x_dofmap, cells[i], md::full_extent);
+    for (std::size_t i = 0; i < x_dofs.size(); ++i)
+      std::copy_n(x.data() + (3 * x_dofs[i]), gdim,
+                  std::next(cdofs.begin(), gdim * i));
+
+    std::span<const T> target_point(points.data() + 3 * i, 3);
+
+    constexpr T sigma = 0.1;
+    constexpr T beta = 0.5;
 
     // Update Initial guess
     std::ranges::copy(initial_guess, x_k.begin());
-    // for (std::size_t k = 0; k < max_iter; ++k)
-    // {
-    //   // 1. Projection
-    //   impl::projection<T, tdim, is_simplex>(x_k, projected);
+    for (std::size_t k = 0; k < max_iter; k++)
+    {
+      std::ranges::copy(x_k, x_old.begin());
 
-    //   // 2. Compute closest point and gradient
-    //   T dist;
-    //   std::array<T, 3> g;
-    //   std::tie(closest_points[i], dist, g) = e.evaluate_closest_point(
-    //       cells[i], projected.data(), point.data());
+      // Tabulate basis function and gradient at current point
+      std::ranges::fill(dphi_b, 0);
+      cmap.tabulate(1, std::span(x_k.data(), tdim), {1, tdim}, dphi_b);
 
-    //   // Check convergence
-    //   if (dist < tol_dist || dist < roundoff_tol)
-    //     break;
+      // Push forward to physicalspace
+      dolfinx::fem::CoordinateElement<T>::push_forward(surface_point,
+                                                       cell_geometry, phi);
+
+      // Compute objective function (squared distance to point)/2
+      std::ranges::transform(X_phys_buffer, target_point, diff.begin(),
+                             [](T xpi, T tpi) { return xpi - tpi; });
+
+      T current_dist_sq
+          = 0.5
+            * std::inner_product(diff.begin(), diff.end(), diff.begin(), T(0));
+
+      // Compute Jacobian (tangent vectors)
+      std::ranges::fill(J_buffer, 0);
+      dolfinx::fem::CoordinateElement<T>::compute_jacobian(dphi, cell_geometry,
+                                                           J);
+
+      // Compute tangents (J^T diff)
+      std::ranges::fill(gradient, 0);
+      for (std::size_t l = 0; l < gdim; ++l)
+        for (std::size_t m = 0; m < tdim; ++m)
+          gradient[m] += J(l, m) * diff[l];
+
+      // Check for convergence in gradient norm, scaled by Jacobian to account
+      // for stretching of the reference space
+      T jac_norm = std::sqrt(std::inner_product(J_buffer.data(),
+                                                J_buffer.data() + (gdim * tdim),
+                                                J_buffer.data(), T(0)));
+      T scaled_tol_grad = tol_grad * std::max(jac_norm, T(1));
+      if (std::sqrt(std::inner_product(gradient.begin(), gradient.end(),
+                                       gradient.begin(), T(0)))
+          < scaled_tol_grad)
+      {
+        break;
+      }
+
+      // Goldstein-Polyak-Levitin Projected Line Search
+      // Bertsekas (1976) Eq. (14) - Armijo Rule along the Projection Arc
+
+      std::ranges::fill(x_new_prev, -1);
+      bool target_reached = false;
+      T alpha = 1.0;
+      for (std::size_t ls_iter = 0; ls_iter < max_ls_iter; ++ls_iter)
+      { // Take projected gradient step
+        std::array<T, tdim> x_k_tmp;
+
+        // Compute new step xk - alpha * g and project back to domain
+        std::ranges::transform(x_k, gradient, x_k_tmp.begin(),
+                               [alpha](T xki, T gi)
+                               { return xki - alpha * gi; });
+
+        impl::projection<T, tdim, is_simplex>(x_k_tmp, x_new);
+
+        // The projection is pinned to the boundary, terminate search
+        T local_diff = std::sqrt(
+            std::inner_product(x_new.begin(), x_new.end(), x_new_prev.begin(),
+                               T(0), std::plus<T>(), [](T xni, T xki)
+                               { return (xni - xki) * (xni - xki); }));
+        if (local_diff < eps)
+          break;
+
+        std::ranges::copy(x_new, x_new_prev.begin());
+
+        // Size of step after projecting back to boundary
+        std::array<T, tdim> actual_step;
+        std::ranges::transform(x_k, x_new, actual_step.begin(),
+                               [](T xki, T xni) { return xni - xki; });
+        // Evaluate distance at new point
+
+        std::ranges::fill(dphi_b, basis_data_size);
+        cmap.tabulate(0, std::span(x_k.data(), tdim), {1, tdim},
+                      std::span(dphi_b.data(), basis_data_size));
+
+        // Push forward to physical space
+        dolfinx::fem::CoordinateElement<T>::push_forward(surface_point,
+                                                         cell_geometry, phi);
+
+        // Compute objective function (squared distance to point)/2
+        std::ranges::transform(X_phys_buffer, target_point, diff.begin(),
+                               [](T xpi, T tpi) { return xpi - tpi; });
+
+        T new_sq_dist = 0.5
+                        * std::inner_product(diff.begin(), diff.end(),
+                                             diff.begin(), T(0));
+
+        // If we are close enough to the targetpoint we terminate the
+        // linesearch, even if the Armijo condition is not satisfied, to avoid
+        // unnecessary iterations close to the target point.
+        if (new_sq_dist < 0.5 * tol_dist * tol_dist)
+        {
+          target_reached = true;
+          break;
+        }
+
+        // Bertsekas Eq. (14) condition:
+        // f(x_new) <= f(x_k) + sigma * grad_f(x_k)^T * (x_new - x_k)
+        // Note: g is grad_f(x_k)
+        if (new_sq_dist
+            <= current_dist_sq
+                   - sigma
+                         * std::inner_product(gradient.begin(), gradient.end(),
+                                              actual_step.begin(), T(0))
+                   + roundoff_tol)
+        {
+          break;
+        }
+
+        alpha *= beta;
+        if (ls_iter == max_ls_iter - 1)
+        {
+          std::cout << "Line search failed to find a suitable step after "
+                    << max_ls_iter << " iterations." << std::endl;
+        }
+      }
+
+      std::ranges::copy(x_new, x_k.begin());
+      if (target_reached)
+        break;
+
+      // Check if Newton iteration has converged
+      if (std::sqrt(std::inner_product(x_k.begin(), x_k.end(), x_old.begin(),
+                                       T(0), std::plus<T>(), [](T xki, T xoi)
+                                       { return (xki - xoi) * (xki - xoi); }))
+          < tol_x)
+        break;
+
+      if (k == max_iter - 1)
+      {
+        throw std::runtime_error("Newton iteration failed to converge after "
+                                 + std::to_string(max_iter) + " iterations.");
+      }
+
+      // Push forward to physicalspace for closest point
+      cmap.tabulate(0, std::span(x_k.data(), tdim), {1, tdim},
+                    std::span(dphi_b.data(), basis_data_size));
+      dolfinx::fem::CoordinateElement<T>::push_forward(surface_point,
+                                                       cell_geometry, phi);
+      std::copy_n(X_phys_buffer.data(), gdim,
+                  std::next(closest_points.begin(), 3 * i));
+      std::copy_n(x_k.begin(), tdim,
+                  std::next(reference_points.begin(), tdim * i));
+    }
   }
 
   return {std::move(closest_points), std::move(reference_points)};
@@ -566,6 +744,7 @@ void declare_closest_point(nanobind::module_& m, std::string type)
       {
         std::size_t tdim
             = dolfinx::mesh::cell_dim(mesh.topology()->cell_type());
+        std::size_t gdim = mesh.geometry().dim();
         bool is_simplex
             = (mesh.topology()->cell_type() == dolfinx::mesh::CellType::triangle
                || mesh.topology()->cell_type()
@@ -573,43 +752,147 @@ void declare_closest_point(nanobind::module_& m, std::string type)
         switch (tdim)
         {
         case 1:
-          return scifem::closest_point_projection<T, 1, false>(
-              mesh, std::span<const std::int32_t>(cells.data(), cells.size()),
-              std::span<const T>(points.data(), points.size()), tol_x, tol_dist,
-              tol_grad, max_iter, max_ls_iter);
+        {
+          switch (gdim)
+          {
+          case 1:
+          {
+            auto [closest_point, closest_ref]
+                = scifem::closest_point_projection<T, 1, false, 1>(
+                    mesh,
+                    std::span<const std::int32_t>(cells.data(), cells.size()),
+                    std::span<const T>(points.data(), points.size()), tol_x,
+                    tol_dist, tol_grad, max_iter, max_ls_iter);
+            return std::make_tuple(
+                as_nbarray(closest_point, {cells.size(), 3}),
+                as_nbarray(closest_ref, {cells.size(), tdim}));
+          }
+          case 2:
+          {
+            auto [closest_point, closest_ref]
+                = scifem::closest_point_projection<T, 1, false, 2>(
+                    mesh,
+                    std::span<const std::int32_t>(cells.data(), cells.size()),
+                    std::span<const T>(points.data(), points.size()), tol_x,
+                    tol_dist, tol_grad, max_iter, max_ls_iter);
+            return std::make_tuple(
+                as_nbarray(closest_point, {cells.size(), 3}),
+                as_nbarray(closest_ref, {cells.size(), tdim}));
+          }
+          case 3:
+          {
+            auto [closest_point, closest_ref]
+                = scifem::closest_point_projection<T, 1, false, 3>(
+                    mesh,
+                    std::span<const std::int32_t>(cells.data(), cells.size()),
+                    std::span<const T>(points.data(), points.size()), tol_x,
+                    tol_dist, tol_grad, max_iter, max_ls_iter);
+            return std::make_tuple(
+                as_nbarray(closest_point, {cells.size(), 3}),
+                as_nbarray(closest_ref, {cells.size(), tdim}));
+          };
+
+          default:
+            throw std::runtime_error("Unsupported geometric dimension");
+          }
+        }
         case 2:
         {
           if (is_simplex)
           {
-            return scifem::closest_point_projection<T, 2, true>(
-                mesh, std::span<const std::int32_t>(cells.data(), cells.size()),
-                std::span<const T>(points.data(), points.size()), tol_x,
-
-                tol_dist, tol_grad, max_iter, max_ls_iter);
+            switch (gdim)
+            {
+            case 2:
+            {
+              auto [closest_point, closest_ref]
+                  = scifem::closest_point_projection<T, 2, true, 2>(
+                      mesh,
+                      std::span<const std::int32_t>(cells.data(), cells.size()),
+                      std::span<const T>(points.data(), points.size()), tol_x,
+                      tol_dist, tol_grad, max_iter, max_ls_iter);
+              return std::make_tuple(
+                  as_nbarray(closest_point, {cells.size(), 3}),
+                  as_nbarray(closest_ref, {cells.size(), tdim}));
+            }
+            case 3:
+            {
+              auto [closest_point, closest_ref]
+                  = scifem::closest_point_projection<T, 2, true, 3>(
+                      mesh,
+                      std::span<const std::int32_t>(cells.data(), cells.size()),
+                      std::span<const T>(points.data(), points.size()), tol_x,
+                      tol_dist, tol_grad, max_iter, max_ls_iter);
+              return std::make_tuple(
+                  as_nbarray(closest_point, {cells.size(), 3}),
+                  as_nbarray(closest_ref, {cells.size(), tdim}));
+            }
+            default:
+              throw std::runtime_error("Unsupported geometric dimension");
+            }
           }
           else
           {
-            return scifem::closest_point_projection<T, 2, false>(
-                mesh, std::span<const std::int32_t>(cells.data(), cells.size()),
-                std::span<const T>(points.data(), points.size()), tol_x,
-                tol_dist, tol_grad, max_iter, max_ls_iter);
+            switch (gdim)
+            {
+            case 2:
+            {
+              auto [closest_point, closest_ref]
+                  = scifem::closest_point_projection<T, 2, false, 2>(
+                      mesh,
+                      std::span<const std::int32_t>(cells.data(), cells.size()),
+                      std::span<const T>(points.data(), points.size()), tol_x,
+                      tol_dist, tol_grad, max_iter, max_ls_iter);
+              return std::make_tuple(
+                  as_nbarray(closest_point, {cells.size(), 3}),
+                  as_nbarray(closest_ref, {cells.size(), tdim}));
+            }
+            case 3:
+            {
+              auto [closest_point, closest_ref]
+                  = scifem::closest_point_projection<T, 2, false, 3>(
+                      mesh,
+                      std::span<const std::int32_t>(cells.data(), cells.size()),
+                      std::span<const T>(points.data(), points.size()), tol_x,
+                      tol_dist, tol_grad, max_iter, max_ls_iter);
+              return std::make_tuple(
+                  as_nbarray(closest_point, {cells.size(), 3}),
+                  as_nbarray(closest_ref, {cells.size(), tdim}));
+            }
+            default:
+              throw std::runtime_error("Unsupported geometric dimension");
+            }
           }
         }
         case 3:
         {
           if (is_simplex)
-            return scifem::closest_point_projection<T, 3, true>(
-                mesh, std::span<const std::int32_t>(cells.data(), cells.size()),
-                std::span<const T>(points.data(), points.size()), tol_x,
-                tol_dist, tol_grad, max_iter, max_ls_iter);
+          {
+            auto [closest_point, closest_ref]
+                = scifem::closest_point_projection<T, 3, true, 3>(
+                    mesh,
+                    std::span<const std::int32_t>(cells.data(), cells.size()),
+                    std::span<const T>(points.data(), points.size()), tol_x,
+                    tol_dist, tol_grad, max_iter, max_ls_iter);
+            return std::make_tuple(
+                as_nbarray(closest_point, {cells.size(), 3}),
+                as_nbarray(closest_ref, {cells.size(), tdim}));
+          }
           else
-            return scifem::closest_point_projection<T, 3, false>(
-                mesh, std::span<const std::int32_t>(cells.data(), cells.size()),
-                std::span<const T>(points.data(), points.size()), tol_x,
-                tol_dist, tol_grad, max_iter, max_ls_iter);
-        }
+          {
+            auto [closest_point, closest_ref]
+                = scifem::closest_point_projection<T, 3, false, 3>(
+                    mesh,
+                    std::span<const std::int32_t>(cells.data(), cells.size()),
+                    std::span<const T>(points.data(), points.size()), tol_x,
+                    tol_dist, tol_grad, max_iter, max_ls_iter);
+            return std::make_tuple(
+                as_nbarray(closest_point, {cells.size(), 3}),
+                as_nbarray(closest_ref, {cells.size(), tdim}));
+          }
+
         default:
           throw std::runtime_error("Unsupported cell dimension");
+        }
         }
       },
       nanobind::arg("mesh"), nanobind::arg("cells"), nanobind::arg("points"),

--- a/src/scifem.cpp
+++ b/src/scifem.cpp
@@ -371,8 +371,12 @@ std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
           alpha *= beta;
           if (ls_iter == max_ls_iter - 1)
           {
-            std::cout << "Line search failed to find a suitable step after "
-                      << max_ls_iter << " iterations." << std::endl;
+            std::string out_msg
+                = "Line search failed to find a suitable step after {} "
+                  "iterations. "
+                  "Current dist: {}, grad_dot_step: {}, alpha: {}";
+            out_msg = std::format(out_msg, max_ls_iter, new_sq_dist, grad);
+            std::cout << out_msg << std::endl;
           }
         }
 
@@ -389,8 +393,11 @@ std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
 
         if (k == max_iter - 1)
         {
-          throw std::runtime_error("Newton iteration failed to converge after "
-                                   + std::to_string(max_iter) + " iterations.");
+          std::string error_msg
+              = std::format("Newton iteration failed to converge after {} "
+                            "iterations. x_diff_sq={} J={}",
+                            max_iter, x_diff_sq, current_dist_sq);
+          throw std::runtime_error(error_msg);
         }
       }
       // Push forward to physicalspace for closest point

--- a/src/scifem.cpp
+++ b/src/scifem.cpp
@@ -375,7 +375,7 @@ std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
                 = "Line search failed to find a suitable step after {} "
                   "iterations. "
                   "Current dist: {}, grad_dot_step: {}, alpha: {}";
-            out_msg = std::format(out_msg, max_ls_iter, new_sq_dist, grad);
+            out_msg = std::format(out_msg, new_sq_dist, grad_dot_step, alpha);
             std::cout << out_msg << std::endl;
           }
         }

--- a/src/scifem.cpp
+++ b/src/scifem.cpp
@@ -93,7 +93,7 @@ inline void simplex_projection(const std::array<T, tdim>& x,
   std::ranges::transform(x, u.begin(),
                          [](auto xi) { return std::max(xi, T(0)); });
   T sum = std::accumulate(u.begin(), u.end(), T(0));
-  if (sum <= 1.0)
+  if (sum <= (T)1.0)
   {
     if constexpr (tdim == 2)
     {
@@ -122,8 +122,8 @@ inline void simplex_projection(const std::array<T, tdim>& x,
     impl::sort_array_2_descending(x_sorted);
     cumsum[0] = x_sorted[0];
     cumsum[1] = x_sorted[0] + x_sorted[1];
-    Ks[0] = x_sorted[0] > (cumsum[0] - 1.0);
-    Ks[1] = x_sorted[1] * 2 > (cumsum[1] - 1.0);
+    Ks[0] = x_sorted[0] > (cumsum[0] - (T)1.0);
+    Ks[1] = x_sorted[1] * (T)2 > (cumsum[1] - (T)1.0);
     if (Ks[1])
       K = 2;
     else if (Ks[0])
@@ -137,9 +137,9 @@ inline void simplex_projection(const std::array<T, tdim>& x,
     cumsum[0] = x_sorted[0];
     cumsum[1] = x_sorted[0] + x_sorted[1];
     cumsum[2] = x_sorted[0] + x_sorted[1] + x_sorted[2];
-    Ks[0] = x_sorted[0] > (cumsum[0] - 1.0);
-    Ks[1] = x_sorted[1] * 2 > (cumsum[1] - 1.0);
-    Ks[2] = x_sorted[2] * 3 > (cumsum[2] - 1.0);
+    Ks[0] = x_sorted[0] > (cumsum[0] - (T)1.0);
+    Ks[1] = x_sorted[1] * (T)2 > (cumsum[1] - (T)1.0);
+    Ks[2] = x_sorted[2] * (T)3 > (cumsum[2] - (T)1.0);
     if (Ks[2])
       K = 3;
     else if (Ks[1])
@@ -153,7 +153,7 @@ inline void simplex_projection(const std::array<T, tdim>& x,
   {
     static_assert(tdim == 2 || tdim == 3, "Unsupported dimension");
   }
-  T tau = (cumsum[K - 1] - 1.0) / (K);
+  T tau = (cumsum[K - 1] - (T)1.0) / T(K);
   for (std::size_t i = 0; i < tdim; ++i)
     projected[i] = std::max(x[i] - tau, T(0));
 };

--- a/src/scifem.cpp
+++ b/src/scifem.cpp
@@ -184,7 +184,7 @@ std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
   constexpr T roundoff_tol = 100 * eps;
 
   const dolfinx::fem::CoordinateElement<T>& cmap = mesh.geometry().cmap();
-  std::vector<T> closest_points(3 * cells.size());
+  std::vector<T> closest_points(3 * cells.size(), T(0));
   assert(cells.size() == points.size() / 3);
   std::vector<T> reference_points(cells.size() * tdim);
 
@@ -215,6 +215,9 @@ std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
   std::array<T, tdim> gradient;
   std::array<T, tdim> x_new_prev;
   std::array<T, tdim> x_new;
+  std::array<T, tdim> x_k_tmp;
+  std::array<T, gdim> target_point;
+
   md::mdspan<T, md::extents<std::size_t, gdim, tdim>> J(J_buffer.data(), gdim,
                                                         tdim);
 
@@ -230,6 +233,9 @@ std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
   md::mdspan<const T, md::dextents<std::size_t, 2>> cell_geometry(
       cdofs.data(), x_dofmap.extent(1), gdim);
 
+  constexpr T sigma = 0.1;
+  constexpr T beta = 0.5;
+
   for (std::size_t i = 0; i < cells.size(); ++i)
   {
     // Pack cell geometry into mdspan for push_forward
@@ -238,16 +244,15 @@ std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
       std::copy_n(x.data() + (3 * x_dofs[k]), gdim,
                   std::next(cdofs.begin(), gdim * k));
 
-    std::span<const T> target_point(points.data() + 3 * i, 3);
-
-    constexpr T sigma = 0.1;
-    constexpr T beta = 0.5;
+    std::copy(points.data() + (3 * i), points.data() + (3 * i) + gdim,
+              target_point.begin());
 
     // Update Initial guess
     std::ranges::copy(initial_guess, x_k.begin());
     for (std::size_t k = 0; k < max_iter; k++)
     {
-      std::ranges::copy(x_k, x_old.begin());
+      for (std::size_t l = 0; l < tdim; ++l)
+        x_old[l] = x_k[l];
 
       // Tabulate basis function and gradient at current point
       std::ranges::fill(dphi_b, 0);
@@ -258,70 +263,65 @@ std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
                                                        cell_geometry, phi);
 
       // Compute objective function (squared distance to point)/2
-      std::ranges::transform(X_phys_buffer, target_point, diff.begin(),
-                             [](T xpi, T tpi) { return xpi - tpi; });
-
-      T current_dist_sq
-          = 0.5
-            * std::inner_product(diff.begin(), diff.end(), diff.begin(), T(0));
+      T current_dist_sq = 0;
+      for (std::size_t d = 0; d < gdim; ++d)
+      {
+        diff[d] = X_phys_buffer[d] - target_point[d];
+        current_dist_sq += diff[d] * diff[d];
+      }
+      current_dist_sq *= T(0.5);
 
       // Compute Jacobian (tangent vectors)
-      std::ranges::fill(J_buffer, 0);
+      for (std::size_t l = 0; l < tdim * gdim; l++)
+        J_buffer[l] = 0;
       dolfinx::fem::CoordinateElement<T>::compute_jacobian(dphi, cell_geometry,
                                                            J);
 
       // Compute tangents (J^T diff)
-      std::ranges::fill(gradient, 0);
+      for (std::size_t m = 0; m < tdim; ++m)
+        gradient[m] = 0;
       for (std::size_t l = 0; l < gdim; ++l)
         for (std::size_t m = 0; m < tdim; ++m)
           gradient[m] += J(l, m) * diff[l];
 
       // Check for convergence in gradient norm, scaled by Jacobian to account
       // for stretching of the reference space
-      T jac_norm = std::sqrt(std::inner_product(J_buffer.data(),
-                                                J_buffer.data() + (gdim * tdim),
-                                                J_buffer.data(), T(0)));
+      T jac_norm = 0;
+      for (std::size_t l = 0; l < tdim * gdim; l++)
+        jac_norm += J_buffer[l] * J_buffer[l];
       T scaled_tol_grad = tol_grad * std::max(jac_norm, T(1));
-      if (std::sqrt(std::inner_product(gradient.begin(), gradient.end(),
-                                       gradient.begin(), T(0)))
-          < scaled_tol_grad)
+      T g_squared = 0;
+      for (std::size_t l = 0; l < tdim; ++l)
+        g_squared += gradient[l] * gradient[l];
+      if (g_squared < scaled_tol_grad)
       {
         break;
       }
 
       // Goldstein-Polyak-Levitin Projected Line Search
       // Bertsekas (1976) Eq. (14) - Armijo Rule along the Projection Arc
-
-      std::ranges::fill(x_new_prev, -1);
+      for (std::size_t l = 0; l < tdim; ++l)
+        x_new_prev[l] = -1;
       bool target_reached = false;
       T alpha = 1.0;
       for (std::size_t ls_iter = 0; ls_iter < max_ls_iter; ++ls_iter)
-      { // Take projected gradient step
-        std::array<T, tdim> x_k_tmp;
-
+      {
+        // Take projected gradient step
         // Compute new step xk - alpha * g and project back to domain
-        std::ranges::transform(x_k, gradient, x_k_tmp.begin(),
-                               [alpha](T xki, T gi)
-                               { return xki - alpha * gi; });
-
+        for (std::size_t l = 0; l < tdim; l++)
+          x_k_tmp[l] = x_k[l] - alpha * gradient[l];
         impl::projection<T, tdim, is_simplex>(x_k_tmp, x_new);
 
         // The projection is pinned to the boundary, terminate search
-        T local_diff = std::sqrt(
-            std::inner_product(x_new.begin(), x_new.end(), x_new_prev.begin(),
-                               T(0), std::plus<T>(), [](T xni, T xki)
-                               { return (xni - xki) * (xni - xki); }));
-        if (local_diff < eps)
+        T local_diff = 0;
+        for (std::size_t l = 0; l < tdim; l++)
+          local_diff += (x_new[l] - x_new_prev[l]) * (x_new[l] - x_new_prev[l]);
+        if (local_diff < eps * eps)
           break;
+        for (std::size_t l = 0; l < tdim; l++)
+          x_new_prev[l] = x_new[l];
 
-        std::ranges::copy(x_new, x_new_prev.begin());
-
-        // Size of step after projecting back to boundary
-        std::array<T, tdim> actual_step;
-        std::ranges::transform(x_k, x_new, actual_step.begin(),
-                               [](T xki, T xni) { return xni - xki; });
         // Evaluate distance at new point
-
         std::ranges::fill(std::span(dphi_b.data(), basis_data_size), T(0));
         cmap.tabulate(0, std::span(x_new.data(), tdim), {1, tdim},
                       std::span(dphi_b.data(), basis_data_size));
@@ -331,12 +331,13 @@ std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
                                                          cell_geometry, phi);
 
         // Compute objective function (squared distance to point)/2
-        std::ranges::transform(X_phys_buffer, target_point, diff.begin(),
-                               [](T xpi, T tpi) { return xpi - tpi; });
-
-        T new_sq_dist = 0.5
-                        * std::inner_product(diff.begin(), diff.end(),
-                                             diff.begin(), T(0));
+        T new_sq_dist = 0;
+        for (std::size_t l = 0; l < gdim; ++l)
+        {
+          diff[l] = X_phys_buffer[l] - target_point[l];
+          new_sq_dist += diff[l] * diff[l];
+        }
+        new_sq_dist *= 0.5;
 
         // If we are close enough to the targetpoint we terminate the
         // linesearch, even if the Armijo condition is not satisfied, to avoid
@@ -350,12 +351,12 @@ std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
         // Bertsekas Eq. (14) condition:
         // f(x_new) <= f(x_k) + sigma * grad_f(x_k)^T * (x_new - x_k)
         // Note: g is grad_f(x_k)
+        // Size of step after projecting back to boundary
+        T grad_dot_step = 0;
+        for (std::size_t d = 0; d < tdim; ++d)
+          grad_dot_step += gradient[d] * (x_new[d] - x_k[d]);
         if (new_sq_dist
-            <= current_dist_sq
-                   + sigma
-                         * std::inner_product(gradient.begin(), gradient.end(),
-                                              actual_step.begin(), T(0))
-                   + roundoff_tol)
+            <= current_dist_sq + sigma * grad_dot_step + roundoff_tol)
         {
           break;
         }
@@ -373,10 +374,10 @@ std::tuple<std::vector<T>, std::vector<T>> closest_point_projection(
         break;
 
       // Check if Newton iteration has converged
-      if (std::sqrt(std::inner_product(x_k.begin(), x_k.end(), x_old.begin(),
-                                       T(0), std::plus<T>(), [](T xki, T xoi)
-                                       { return (xki - xoi) * (xki - xoi); }))
-          < tol_x)
+      T x_diff_sq = 0;
+      for (std::size_t l = 0; l < tdim; l++)
+        x_diff_sq += (x_k[l] - x_old[l]) * (x_k[l] - x_old[l]);
+      if (x_diff_sq < tol_x * tol_x)
         break;
 
       if (k == max_iter - 1)

--- a/src/scifem/__init__.py
+++ b/src/scifem/__init__.py
@@ -22,6 +22,7 @@ from .mesh import (
 )
 from .eval import evaluate_function, find_cell_extrema, compute_extrema
 from .interpolation import interpolation_matrix, prepare_interpolation_data
+from .geometry import closest_point_projection
 
 meta = metadata("scifem")
 __version__ = meta["Version"]
@@ -38,6 +39,7 @@ __all__ = [
     "__email__",
     "__program_name__",
     "PointSource",
+    "closest_point_projection",
     "assemble_scalar",
     "create_space_of_simple_functions",
     "compute_interface_data",

--- a/src/scifem/geometry.py
+++ b/src/scifem/geometry.py
@@ -135,7 +135,6 @@ def closest_point_projection(
             # Compute current objective function
             diff = surface_point - target_point
             current_dist_sq = 0.5 * np.linalg.norm(diff) ** 2
-
             # Compute the gradient in reference coordinates using the Jacobian (tangent vectors)
             tangents = np.dot(tab[1 : tdim + 1, 0, :], coord)
             g = np.dot(tangents, diff)
@@ -143,6 +142,7 @@ def closest_point_projection(
             # Check for convergence in gradient norm, scaled by the Jacobian to account
             # for stretching of the reference space
             jac_norm = np.linalg.norm(tangents)
+
             scaled_tol_grad = tol_grad * max(jac_norm, 1.0)
             if np.linalg.norm(g) < scaled_tol_grad:
                 break
@@ -158,6 +158,7 @@ def closest_point_projection(
             for li in range(max_ls_iter):
                 # Apply the exact analytical simplex projection
                 x_new = project(x_k - alpha * g)
+                # breakpoint()
 
                 if np.linalg.norm(x_new - x_new_prev) < eps:
                     # The projection is pinned to a boundary.

--- a/src/scifem/geometry.py
+++ b/src/scifem/geometry.py
@@ -120,6 +120,7 @@ def closest_point_projection(
             return np.clip(x, 0.0, 1.0)
 
     for i, (coord, target_point) in enumerate(zip(node_coords, target_points)):
+        target_point = target_point[: mesh.geometry.dim]
         coord = coord.reshape(-1, mesh.geometry.dim)
         x_k = initial_guess.copy()
 

--- a/src/scifem/geometry.py
+++ b/src/scifem/geometry.py
@@ -2,6 +2,7 @@ import dolfinx
 import numpy as np
 import numpy.typing as npt
 import warnings
+from scifem._scifem import closest_point_projection_float64, closest_point_projection_float32
 
 
 def project_onto_simplex(
@@ -52,9 +53,9 @@ def closest_point_projection(
     tol_grad: float = 1e-10,
     max_iter: int = 2000,
     max_ls_iter: int = 250,
-) -> tuple[npt.NDArray[np.float64 | np.float32], npt.NDArray[np.float64 | np.float32]]:
-    """
-    Projects a 3D point onto a cell in a potentially higher order mesh.
+    num_threads: int = 1,
+):
+    """Projects a 3D point onto a cell in a potentially higher order mesh.
 
     Uses the Goldstein-Levitin-Polyak Gradient projection method, where
     potential simplex constraints are handled by an exact projection using a
@@ -64,11 +65,85 @@ def closest_point_projection(
     - Dimitri P. Bertsekas, "On the Goldstein-Levitin-Polyak gradient projection method," (1976)
 
     Args:
-        mesh: {py:class}`dolfinx.mesh.Mesh`, the mesh containing the cell.
-        cells: {py:class}`numpy.ndarray`, the local indices of the cells to project onto.
-        target_point: (3,) numpy array, the 3D point to project.
+        mesh: The mesh containing the cells.
+        cells: The local indices of the cells to project onto.
+        target_points: (n, 3) numpy array, the 3D points to project.
         tol_x: Tolerance for changes between iterates in the reference coordinates.
-        If None, uses the square root of machine precision.
+            If None, uses the square root of machine precision.
+        tol_grad: Tolerance for determination based on the gradient norm.
+            The gradient is scaled by the Jacobian to account for stretching.
+        tol_dist: Tolerance used to determine if the projected point is close enough to
+            the target point to stop optimization.
+        max_iter: int, the maximum number of iterations for the projected gradient method.
+        max_ls_iter: int, the maximum number of line search iterations.
+        num_threads: int, the number of threads to use for parallel projection.
+
+    Returns:
+        A tuple of arrays containing the closest points (in physical space)
+        and reference coordinates for each cell to each target point.
+    """
+    xdtype = mesh.geometry.x.dtype
+
+    if xdtype == np.float64:
+        return closest_point_projection_float64(
+            mesh._cpp_object,
+            cells,
+            target_points,
+            tol_x=tol_x,
+            tol_dist=tol_dist,
+            tol_grad=tol_grad,
+            max_iter=max_iter,
+            max_ls_iter=max_ls_iter,
+            num_threads=num_threads,
+        )
+    elif xdtype == np.float32:
+        return closest_point_projection_float32(
+            mesh._cpp_object,
+            cells,
+            target_points,
+            tol_x=tol_x,
+            tol_dist=tol_dist,
+            tol_grad=tol_grad,
+            max_iter=max_iter,
+            max_ls_iter=max_ls_iter,
+            num_threads=num_threads,
+        )
+    else:
+        raise TypeError(f"Unsupported mesh coordinate dtype {xdtype}.")
+
+
+def _closest_point_projection(
+    mesh: dolfinx.mesh.Mesh,
+    cells: npt.NDArray[np.int32],
+    target_points: npt.NDArray[np.float64 | np.float32],
+    tol_x: float | None = None,
+    tol_dist: float = 1e-10,
+    tol_grad: float = 1e-10,
+    max_iter: int = 2000,
+    max_ls_iter: int = 250,
+) -> tuple[npt.NDArray[np.float64 | np.float32], npt.NDArray[np.float64 | np.float32]]:
+    """Projects a 3D point onto a cell in a potentially higher order mesh.
+
+    NOTE:
+        Reference implementation in Python. This should only be used for testing and debugging,
+        and is not optimized for performance. The performant implementation can be found in
+        {py:func}`closest_point_projection`.
+
+    Uses the Goldstein-Levitin-Polyak Gradient projection method, where
+    potential simplex constraints are handled by an exact projection using a
+    primal-dual root finding method. See:
+    - Held, M., Wolfe, P., Crowder, H.: Validation of subgradient optimization (1974)
+    - Laurent Condat. Fast Projection onto the Simplex and the l1 Ball. (2016)
+    - Dimitri P. Bertsekas, "On the Goldstein-Levitin-Polyak gradient projection method," (1976)
+
+    Args:
+        mesh: The mesh containing the cell.
+        cells: The local indices of the cells to project onto.
+        target_points: (n, 3) numpy array, the 3D points to project.
+        tol_x: Tolerance for changes between iterates in the reference coordinates.
+            If None, uses the square root of machine precision.
+        tol_grad: Tolerance for determination based on the gradient norm.
+            The gradient is scaled by the Jacobian to account for stretching.
         tol_dist: Tolerance used to determine if the projected point is close enough to
             the target point to stop optimization.
         max_iter: int, the maximum number of iterations for the projected gradient method.
@@ -89,7 +164,6 @@ def closest_point_projection(
     # Get the coordinates of the nodes for the specified cell
     node_coords = mesh.geometry.x[mesh.geometry.dofmap[cells]][:, :, : mesh.geometry.dim]
     target_points = target_points.reshape(-1, 3)
-    # cmap = mesh.geometry.cmap
 
     # Constraints and Bounds
     cell_type = mesh.topology.cell_type

--- a/src/scifem/geometry.py
+++ b/src/scifem/geometry.py
@@ -233,7 +233,6 @@ def _closest_point_projection(
             for li in range(max_ls_iter):
                 # Apply the exact analytical simplex projection
                 x_new = project(x_k - alpha * g)
-                # breakpoint()
 
                 if np.linalg.norm(x_new - x_new_prev) < eps:
                     # The projection is pinned to a boundary.

--- a/src/scifem/geometry.py
+++ b/src/scifem/geometry.py
@@ -1,0 +1,216 @@
+import dolfinx
+import numpy as np
+import numpy.typing as npt
+import warnings
+
+
+def project_onto_simplex(
+    v: npt.NDArray[np.float64 | np.float32],
+) -> npt.NDArray[np.float64 | np.float32]:
+    """
+    Exact projection of vector v onto the simplex {x >= 0, sum(x) <= 1}.
+
+    See Algorithm 1: Laurent Condat. Fast Projection onto the Simplex and the l1 Ball.
+    Mathematical Programming, Series A, 2016, 158 (1), pp.575-585.
+    ⟨DOI: 10.1007/s10107-015-0946-6⟩.
+
+
+    Args:
+        v: The vector to project onto simplex
+
+    Return:
+        The projection of v onto the simplex.
+
+    """
+    # 1. First try the unconstrained positive quadrant projection
+    v = v.reshape(-1)
+    u = np.maximum(v, 0.0)
+    if np.sum(u) <= 1.0:
+        return u
+
+    # 2. Otherwise, project exactly onto the slanted face sum(x) = 1
+    tdim = len(v)
+    if tdim == 2:
+        sort_v = np.array([max(u[0], u[1]), min(u[0], u[1])])
+        cssv = np.array([sort_v[0], sort_v[0] + sort_v[1]])
+    elif tdim == 3:
+        sort_v = np.sort(v)[::-1]
+        cssv = np.array([sort_v[0], sort_v[0] + sort_v[1], sort_v[0] + sort_v[1] + sort_v[2]])
+    else:
+        raise RuntimeError("Projection onto simplex is only implemented for 2D and 3D vectors.")
+    # cssv = np.cumsum(sort_v)
+
+    # Find the primal-dual root
+    # sum x_i = a
+    # Find K: = max (k in [1,.. N] such that sum_{r=1}^k sort_v[r] - a)/k < u_k
+    # Multiply by k and take the last true entry to get the index rho
+    K = np.nonzero(sort_v * np.arange(1, tdim + 1) > (cssv - 1.0))[0][-1]
+    tau = (cssv[K] - 1.0) / (K + 1.0)
+
+    return np.maximum(v - tau, 0.0)
+
+
+def closest_point_projection(
+    mesh: dolfinx.mesh.Mesh,
+    cells: npt.NDArray[np.int32],
+    target_points: npt.NDArray[np.float64 | np.float32],
+    tol_x: float | None = None,
+    tol_dist: float = 1e-10,
+    tol_grad: float = 1e-10,
+    max_iter: int = 2000,
+    max_ls_iter: int = 250,
+) -> tuple[npt.NDArray[np.float64 | np.float32], npt.NDArray[np.float64 | np.float32]]:
+    """
+    Projects a 3D point onto a cell in a potentially higher order mesh.
+
+    Uses the Goldstein-Levitin-Polyak Gradient projection method, where
+    potential simplex constraints are handled by an exact projection using a
+    primal-dual root finding method. See:
+    - Held, M., Wolfe, P., Crowder, H.: Validation of subgradient optimization (1974)
+    - Laurent Condat. Fast Projection onto the Simplex and the l1 Ball. (2016)
+    - Dimitri P. Bertsekas, "On the Goldstein-Levitin-Polyak gradient projection method," (1976)
+
+    Args:
+        mesh: {py:class}`dolfinx.mesh.Mesh`, the mesh containing the cell.
+        cells: {py:class}`numpy.ndarray`, the local indices of the cells to project onto.
+        target_point: (3,) numpy array, the 3D point to project.
+        tol_x: Tolerance for changes between iterates in the reference coordinates.
+        If None, uses the square root of machine precision.
+        tol_dist: Tolerance used to determine if the projected point is close enough to
+            the target point to stop optimization.
+        max_iter: int, the maximum number of iterations for the projected gradient method.
+        max_ls_iter: int, the maximum number of line search iterations.
+
+    Returns:
+        A tuple of arrays containing the closest points (in physical space)
+        and reference coordinates for each cell to each target point.
+    """
+    dtype = mesh.geometry.x.dtype
+    eps = np.finfo(dtype).eps
+    tol_x = np.sqrt(eps) if tol_x is None else tol_x
+    roundoff_tol = 100 * eps
+
+    # Extract scalar element of mesh
+    element = mesh.ufl_domain().ufl_coordinate_element().sub_elements[0]
+    tdim = mesh.topology.dim
+    # Get the coordinates of the nodes for the specified cell
+    node_coords = mesh.geometry.x[mesh.geometry.dofmap[cells]][:, :, : mesh.geometry.dim]
+    target_points = target_points.reshape(-1, 3)
+    # cmap = mesh.geometry.cmap
+
+    # Constraints and Bounds
+    cell_type = mesh.topology.cell_type
+
+    # Set initial guess and tolerance for solver
+    initial_guess = np.full(mesh.topology.dim, 1 / (mesh.topology.dim + 1), dtype=dtype)
+    closest_points = np.zeros((target_points.shape[0], 3), dtype=dtype)
+    reference_points = np.zeros((target_points.shape[0], mesh.topology.dim), dtype=dtype)
+    is_simplex = cell_type in [
+        dolfinx.mesh.CellType.triangle,
+        dolfinx.mesh.CellType.tetrahedron,
+    ]
+
+    if is_simplex:
+
+        def project(x):
+            return project_onto_simplex(x)
+    else:
+
+        def project(x):
+            return np.clip(x, 0.0, 1.0)
+
+    for i, (coord, target_point) in enumerate(zip(node_coords, target_points)):
+        coord = coord.reshape(-1, mesh.geometry.dim)
+        x_k = initial_guess.copy()
+
+        for k in range(max_iter):
+            x_old = x_k.copy()
+
+            # 1. Evaluate ONLY the Value and First Derivative (Gradient)
+            tab = element.tabulate(1, x_k.reshape(1, tdim))
+            surface_point = np.dot(tab[0, 0, :], coord)
+            diff = surface_point - target_point
+            current_dist_sq = 0.5 * np.linalg.norm(diff) ** 2
+
+            tangents = np.dot(tab[1 : tdim + 1, 0, :], coord)
+            g = np.dot(tangents, diff)
+
+            # SCALED GRADIENT TOLERANCE
+            jac_norm = np.linalg.norm(tangents)
+            scaled_tol_grad = tol_grad * max(jac_norm, 1.0)
+            if np.linalg.norm(g) < scaled_tol_grad:
+                break
+            # 2. First-Order Step Direction
+            p = -g
+
+            # 3. Goldstein-Polyak-Levitin Projected Line Search
+            # Bertsekas (1976) Eq. (14) - Armijo Rule along the Projection Arc
+            sigma = 0.1  # Sufficient decrease parameter (0 < sigma < 0.5)
+            beta = 0.5  # Reduction factor (0 < beta < 1)
+            alpha = 1.0  # Initial step size
+
+            x_new_prev = np.full(tdim, -1, dtype=dtype)
+            target_reached = False
+            for li in range(max_ls_iter):
+                # Apply the exact analytical simplex projection
+                x_new = project(x_k + alpha * p)
+
+                if np.linalg.norm(x_new - x_new_prev) < eps:
+                    # The projection is pinned to a boundary.
+                    # Changing alpha further will not change the physical point!
+                    break
+                x_new_prev = x_new.copy()
+                # The actual physical step we took after hitting the geometric walls
+                actual_step = x_new - x_k
+
+                # Evaluate distance at the projected point
+                tab_new = element.tabulate(0, x_new.reshape(1, tdim))
+                S_new = np.dot(tab_new[0, 0, :], coord)
+                new_dist_sq = 0.5 * np.linalg.norm(S_new - target_point) ** 2
+                if new_dist_sq < 0.5 * tol_dist**2:
+                    # We are close enough to the target point, no need for further line search
+                    target_reached = True
+                    break
+
+                # Bertsekas Eq. (14) condition:
+                # f(x_new) <= f(x_k) + sigma * grad_f(x_k)^T * (x_new - x_k)
+                # Note: g is grad_f(x_k)
+                if new_dist_sq <= current_dist_sq + sigma * np.dot(g, actual_step) + roundoff_tol:
+                    # Condition satisfied
+                    break
+
+                # Reduction step (Backtracking)
+                alpha *= beta
+
+            if li == max_ls_iter - 1:
+                warnings.warn(
+                    f"Line search failed to converge after {max_ls_iter} iterations",
+                    f"for cell {cells[i]}  and {target_point=}.",
+                )
+            x_k[:] = x_new
+
+            if target_reached:
+                break
+
+            # 4. Check for convergence
+            if np.linalg.norm(x_k - x_old) < tol_x:
+                break
+            if new_dist_sq < 0.5 * tol_dist**2:
+                print("Projected point is within tolerance of target point, stopping optimization.")
+                break
+
+        assert np.allclose(project(x_k), x_k), "Projection failed to satisfy constraints"
+
+        # Final coordinate extraction
+        tab_final = element.tabulate(0, x_k.reshape(1, tdim))
+        closest_points[i] = np.dot(tab_final[0, 0, :], coord)
+        reference_points[i] = x_k
+
+        if k == max_iter - 1:
+            raise RuntimeError(
+                f"Projected gradient method failed to converge after {max_iter} iterations ",
+                f"for cell {cells[i]} and {target_point=} and final iterate {x_k=} ",
+                f"and final point {closest_points[i]} with final distance ",
+                f"{np.linalg.norm(closest_points[i] - target_point)}.",
+            )
+    return closest_points, reference_points

--- a/src/scifem/geometry.py
+++ b/src/scifem/geometry.py
@@ -126,22 +126,26 @@ def closest_point_projection(
         for k in range(max_iter):
             x_old = x_k.copy()
 
-            # 1. Evaluate ONLY the Value and First Derivative (Gradient)
+            # Evaluate basis functions and first order derivatives at current reference point
             tab = element.tabulate(1, x_k.reshape(1, tdim))
+
+            # Push forward to physical space
             surface_point = np.dot(tab[0, 0, :], coord)
+
+            # Compute current objective function
             diff = surface_point - target_point
             current_dist_sq = 0.5 * np.linalg.norm(diff) ** 2
 
+            # Compute the gradient in reference coordinates using the Jacobian (tangent vectors)
             tangents = np.dot(tab[1 : tdim + 1, 0, :], coord)
             g = np.dot(tangents, diff)
 
-            # SCALED GRADIENT TOLERANCE
+            # Check for convergence in gradient norm, scaled by the Jacobian to account
+            # for stretching of the reference space
             jac_norm = np.linalg.norm(tangents)
             scaled_tol_grad = tol_grad * max(jac_norm, 1.0)
             if np.linalg.norm(g) < scaled_tol_grad:
                 break
-            # 2. First-Order Step Direction
-            p = -g
 
             # 3. Goldstein-Polyak-Levitin Projected Line Search
             # Bertsekas (1976) Eq. (14) - Armijo Rule along the Projection Arc
@@ -153,13 +157,14 @@ def closest_point_projection(
             target_reached = False
             for li in range(max_ls_iter):
                 # Apply the exact analytical simplex projection
-                x_new = project(x_k + alpha * p)
+                x_new = project(x_k - alpha * g)
 
                 if np.linalg.norm(x_new - x_new_prev) < eps:
                     # The projection is pinned to a boundary.
                     # Changing alpha further will not change the physical point!
                     break
                 x_new_prev = x_new.copy()
+
                 # The actual physical step we took after hitting the geometric walls
                 actual_step = x_new - x_k
 

--- a/src/scifem/geometry.py
+++ b/src/scifem/geometry.py
@@ -184,8 +184,8 @@ def closest_point_projection(
 
             if li == max_ls_iter - 1:
                 warnings.warn(
-                    f"Line search failed to converge after {max_ls_iter} iterations",
-                    f"for cell {cells[i]}  and {target_point=}.",
+                    f"Line search failed to converge after {max_ls_iter} iterations "
+                    + f"for cell {cells[i]}  and {target_point=}."
                 )
             x_k[:] = x_new
 

--- a/src/scifem/geometry.py
+++ b/src/scifem/geometry.py
@@ -134,7 +134,7 @@ def closest_point_projection(
 
             # Compute current objective function
             diff = surface_point - target_point
-            current_dist_sq = 0.5 * np.linalg.norm(diff) ** 2
+            current_dist_sq = 0.5 * np.dot(diff, diff)
             # Compute the gradient in reference coordinates using the Jacobian (tangent vectors)
             tangents = np.dot(tab[1 : tdim + 1, 0, :], coord)
             g = np.dot(tangents, diff)
@@ -172,7 +172,7 @@ def closest_point_projection(
                 # Evaluate distance at the projected point
                 tab_new = element.tabulate(0, x_new.reshape(1, tdim))
                 S_new = np.dot(tab_new[0, 0, :], coord)
-                new_dist_sq = 0.5 * np.linalg.norm(S_new - target_point) ** 2
+                new_dist_sq = 0.5 * np.dot(S_new - target_point, S_new - target_point)
                 if new_dist_sq < 0.5 * tol_dist**2:
                     # We are close enough to the target point, no need for further line search
                     target_reached = True

--- a/src/scifem/geometry.py
+++ b/src/scifem/geometry.py
@@ -30,15 +30,8 @@ def project_onto_simplex(
 
     # 2. Otherwise, project exactly onto the slanted face sum(x) = 1
     tdim = len(v)
-    if tdim == 2:
-        sort_v = np.array([max(u[0], u[1]), min(u[0], u[1])])
-        cssv = np.array([sort_v[0], sort_v[0] + sort_v[1]])
-    elif tdim == 3:
-        sort_v = np.sort(v)[::-1]
-        cssv = np.array([sort_v[0], sort_v[0] + sort_v[1], sort_v[0] + sort_v[1] + sort_v[2]])
-    else:
-        raise RuntimeError("Projection onto simplex is only implemented for 2D and 3D vectors.")
-    # cssv = np.cumsum(sort_v)
+    sort_v = np.sort(v)[::-1]
+    cssv = np.cumsum(sort_v)
 
     # Find the primal-dual root
     # sum x_i = a
@@ -102,7 +95,14 @@ def closest_point_projection(
     cell_type = mesh.topology.cell_type
 
     # Set initial guess and tolerance for solver
-    initial_guess = np.full(mesh.topology.dim, 1 / (mesh.topology.dim + 1), dtype=dtype)
+    if (
+        cell_type == dolfinx.mesh.CellType.triangle
+        or cell_type == dolfinx.mesh.CellType.tetrahedron
+    ):
+        plus_val = 1
+    else:
+        plus_val = 0
+    initial_guess = np.full(mesh.topology.dim, 1 / (mesh.topology.dim + plus_val), dtype=dtype)
     closest_points = np.zeros((target_points.shape[0], 3), dtype=dtype)
     reference_points = np.zeros((target_points.shape[0], mesh.topology.dim), dtype=dtype)
     is_simplex = cell_type in [
@@ -200,9 +200,6 @@ def closest_point_projection(
 
             # 4. Check for convergence
             if np.linalg.norm(x_k - x_old) < tol_x:
-                break
-            if new_dist_sq < 0.5 * tol_dist**2:
-                print("Projected point is within tolerance of target point, stopping optimization.")
                 break
 
         assert np.allclose(project(x_k), x_k), "Projection failed to satisfy constraints"

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -47,13 +47,16 @@ def scipy_project_point_to_element(
     ):
         method = method or "SLSQP"
         constraint = {"type": "ineq", "fun": lambda x: 1.0 - np.sum(x)}
+        d = 1.0
     else:
         method = method or "L-BFGS-B"
         constraint = {}
+        d = 0.0
     bounds = [(0.0, 1.0) for _ in range(mesh.topology.dim)]
 
     # Set initial guess and tolerance for solver
-    initial_guess = np.full(mesh.topology.dim, 1 / (mesh.topology.dim + 1), dtype=np.float64)
+
+    initial_guess = np.full(mesh.topology.dim, 1 / (mesh.topology.dim + d), dtype=np.float64)
     tol = np.sqrt(np.finfo(mesh.geometry.x.dtype).eps) if tol is None else tol
     closest_points = np.zeros((target_points.shape[0], 3), dtype=mesh.geometry.x.dtype)
     ref_points = np.zeros((target_points.shape[0], mesh.topology.dim), dtype=mesh.geometry.x.dtype)
@@ -74,7 +77,7 @@ def scipy_project_point_to_element(
         def objective(x_ref):
             surface_point = S(x_ref)
             diff = surface_point - target_point
-            return 0.5 * np.linalg.norm(diff) ** 2
+            return 0.5 * np.dot(diff, diff)
 
         def objective_grad(x_ref):
             diff = S(x_ref) - target_point
@@ -120,7 +123,7 @@ def test_2D_manifold(order, num_threads):
         cells = cells[:, :3]
     mesh = dolfinx.mesh.create_mesh(comm, cells=cells, x=curved_nodes, e=c_el)
 
-    tol_x = 1e-6
+    tol_x = 5e-6
     tol_dist = 1e-7
     theta = np.linspace(0, 4 * np.pi, 10_000)
     rand = np.random.RandomState(42)
@@ -137,38 +140,33 @@ def test_2D_manifold(order, num_threads):
         tol_x=tol_x,
         tol_dist=tol_dist,
         tol_grad=1e-16,
-        max_iter=2000,
-        max_ls_iter=250,
+        max_iter=500,
+        max_ls_iter=50,
         num_threads=num_threads,
     )
 
-    (result_scipy, _ref_scipy) = scipy_project_point_to_element(mesh, cells, points, tol=tol_dist)
+    (result_scipy, _ref_scipy) = scipy_project_point_to_element(mesh, cells, points, tol=tol_x**2)
 
     result, ref_coords = _closest_point_projection(
         mesh, cells, points, tol_x=tol_x, tol_dist=tol_dist
     )
 
-    for i, point_to_project in enumerate(points):
-        # Check that python and C++ implementations give the same result
-        np.testing.assert_allclose(result[i].flatten(), closest_point[i].flatten(), atol=tol_dist)
-        np.testing.assert_allclose(
-            ref_coords[i].flatten(), closest_ref[i].flatten(), atol=10 * tol_dist
-        )
+    # Check that python and C++ implementations give the same result
+    np.testing.assert_allclose(result, closest_point, atol=tol_dist)
+    np.testing.assert_allclose(ref_coords, closest_ref, atol=10 * tol_x)
 
+    # Check that scipy and our implementation give similar distances,
+    # allowing for some tolerance due to different optimization methods
+    diff_scifem = closest_point - points
+    dist_scifem = 0.5 * np.sum(diff_scifem**2, axis=1)
+    diff_scipy = result_scipy - points
+    dist_scipy = 0.5 * np.sum(diff_scipy**2, axis=1)
+    np.testing.assert_allclose(dist_scifem, dist_scipy, atol=50 * tol_dist, rtol=1e-6)
+
+    for coord in closest_ref:
         # Check that we are within the bounds of the simplex
-        ref_proj = project_onto_simplex(ref_coords[i])
-        np.testing.assert_allclose(ref_proj, ref_coords[i])
-
-        # Check that scipy and our implementation give similar distances,
-        # allowing for some tolerance due to different optimization methods
-        dist_scipy = 0.5 * np.dot(
-            result_scipy[i] - point_to_project, result_scipy[i] - point_to_project
-        )
-        dist_ours = 0.5 * np.dot(result[i] - point_to_project, result[i] - point_to_project)
-        if np.isclose(dist_ours, 0.0, atol=tol_dist):
-            assert np.isclose(dist_scipy, 0.0, atol=10 * tol_dist)
-        else:
-            assert np.isclose(dist_ours, dist_scipy, atol=50 * tol_dist, rtol=1e-2)
+        ref_proj = project_onto_simplex(coord)
+        np.testing.assert_allclose(ref_proj, coord)
 
 
 @pytest.mark.parametrize("num_threads", [1, 2, 4])
@@ -202,7 +200,7 @@ def test_3D_curved_cell(order, num_threads):
     rand = np.random.RandomState(32)
     M = 10_000
     points = rand.rand(M, 3) - 0.5 * rand.rand(M, 3)
-    tol_x = 1e-6
+    tol_x = 1e-7
     tol_dist = 1e-7
 
     cells = np.zeros(points.shape[0], dtype=np.int32)
@@ -213,12 +211,11 @@ def test_3D_curved_cell(order, num_threads):
         tol_x=tol_x,
         tol_dist=tol_dist,
         tol_grad=1e-16,
-        max_iter=2000,
-        max_ls_iter=250,
+        max_iter=500,
+        max_ls_iter=50,
         num_threads=num_threads,
     )
-    (result_scipy, ref_scipy) = scipy_project_point_to_element(mesh, cells, points, tol=tol_x)
-
+    (result_scipy, _ref_scipy) = scipy_project_point_to_element(mesh, cells, points, tol=tol_x**2)
     result, ref_coords = _closest_point_projection(
         mesh,
         cells,
@@ -227,21 +224,20 @@ def test_3D_curved_cell(order, num_threads):
         tol_dist=tol_dist,
         tol_grad=1e-16,
     )
-    for i, point_to_project in enumerate(points):
-        np.testing.assert_allclose(result[i].flatten(), closest_point[i].flatten(), atol=tol_dist)
-        np.testing.assert_allclose(
-            ref_coords[i].flatten(), closest_ref[i].flatten(), atol=10 * tol_x
-        )
 
+    # Check that python and C++ implementations give the same result
+    np.testing.assert_allclose(result, closest_point, atol=tol_dist)
+    np.testing.assert_allclose(ref_coords, closest_ref, atol=10 * tol_x)
+
+    # Check that scipy and our implementation give similar distances,
+    # allowing for some tolerance due to different optimization methods
+    diff_scifem = closest_point - points
+    dist_scifem = 0.5 * np.sum(diff_scifem**2, axis=1)
+    diff_scipy = result_scipy - points
+    dist_scipy = 0.5 * np.sum(diff_scipy**2, axis=1)
+    np.testing.assert_allclose(dist_scifem, dist_scipy, atol=50 * tol_dist, rtol=1e-6)
+
+    for coord in closest_ref:
         # Check that we are within the bounds of the simplex
-        ref_proj = project_onto_simplex(ref_coords[i])
-        np.testing.assert_allclose(ref_proj, ref_coords[i])
-
-        dist_scipy = 0.5 * np.dot(
-            result_scipy[i] - point_to_project, result_scipy[i] - point_to_project
-        )
-        dist_ours = 0.5 * np.dot(result[i] - point_to_project, result[i] - point_to_project)
-        if np.isclose(dist_ours, 0.0, atol=tol_dist):
-            assert np.isclose(dist_scipy, 0.0, atol=50 * tol_dist)
-        else:
-            assert np.isclose(dist_ours, dist_scipy, atol=tol_dist, rtol=1e-2)
+        ref_proj = project_onto_simplex(coord)
+        np.testing.assert_allclose(ref_proj, coord)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -142,7 +142,7 @@ def test_2D_manifold(order, num_threads):
         num_threads=num_threads,
     )
 
-    (result_scipy, ref_scipy) = scipy_project_point_to_element(mesh, cells, points, tol=tol_dist)
+    (result_scipy, _ref_scipy) = scipy_project_point_to_element(mesh, cells, points, tol=tol_dist)
 
     result, ref_coords = _closest_point_projection(
         mesh, cells, points, tol_x=tol_x, tol_dist=tol_dist
@@ -161,12 +161,14 @@ def test_2D_manifold(order, num_threads):
 
         # Check that scipy and our implementation give similar distances,
         # allowing for some tolerance due to different optimization methods
-        dist_scipy = 0.5 * np.sum(result_scipy[i] - point_to_project) ** 2
-        dist_ours = 0.5 * np.sum(result[i] - point_to_project) ** 2
-        if not np.isclose(dist_ours, dist_scipy, atol=tol_dist, rtol=1e-2):
-            assert np.linalg.norm(ref_coords[i] - ref_scipy[i]) < 1e-2
+        dist_scipy = 0.5 * np.dot(
+            result_scipy[i] - point_to_project, result_scipy[i] - point_to_project
+        )
+        dist_ours = 0.5 * np.dot(result[i] - point_to_project, result[i] - point_to_project)
+        if np.isclose(dist_ours, 0.0, atol=tol_dist):
+            assert np.isclose(dist_scipy, 0.0, atol=10 * tol_dist)
         else:
-            assert np.isclose(dist_ours, dist_scipy, atol=tol_dist, rtol=1e-2)
+            assert np.isclose(dist_ours, dist_scipy, atol=50 * tol_dist, rtol=1e-2)
 
 
 @pytest.mark.parametrize("num_threads", [1, 2, 4])
@@ -198,7 +200,8 @@ def test_3D_curved_cell(order, num_threads):
     mesh = dolfinx.mesh.create_mesh(comm, cells=cells_tet, x=curved_nodes_tet, e=domain_tet)
 
     rand = np.random.RandomState(32)
-    points = rand.rand(100, 3) - 0.5 * rand.rand(100, 3)
+    M = 10_000
+    points = rand.rand(M, 3) - 0.5 * rand.rand(M, 3)
     tol_x = 1e-6
     tol_dist = 1e-7
 
@@ -234,9 +237,11 @@ def test_3D_curved_cell(order, num_threads):
         ref_proj = project_onto_simplex(ref_coords[i])
         np.testing.assert_allclose(ref_proj, ref_coords[i])
 
-        dist_scipy = 0.5 * np.sum(result_scipy[i] - point_to_project) ** 2
-        dist_ours = 0.5 * np.sum(result[i] - point_to_project) ** 2
-        if not np.isclose(dist_ours, dist_scipy, atol=tol_dist, rtol=1e-2):
-            assert np.linalg.norm(ref_coords[i] - ref_scipy[i]) < 1e-2
+        dist_scipy = 0.5 * np.dot(
+            result_scipy[i] - point_to_project, result_scipy[i] - point_to_project
+        )
+        dist_ours = 0.5 * np.dot(result[i] - point_to_project, result[i] - point_to_project)
+        if np.isclose(dist_ours, 0.0, atol=tol_dist):
+            assert np.isclose(dist_scipy, 0.0, atol=50 * tol_dist)
         else:
             assert np.isclose(dist_ours, dist_scipy, atol=tol_dist, rtol=1e-2)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -214,6 +214,8 @@ def test_3D_curved_cell(order, num_threads):
         max_ls_iter=250,
         num_threads=num_threads,
     )
+    (result_scipy, ref_scipy) = scipy_project_point_to_element(mesh, cells, points, tol=tol_x)
+
     result, ref_coords = _closest_point_projection(
         mesh,
         cells,

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -133,6 +133,20 @@ def test_2D_manifold(order):
         result, ref_coords = closest_point_projection(
             mesh, np.array([0], dtype=np.int32), point_to_project, tol_x=tol, tol_dist=tol_dist
         )
+        import scifem
+
+        scifem._scifem.closest_point_projection_float64(
+            mesh._cpp_object,
+            np.array([0], dtype=np.int32),
+            point_to_project.reshape(-1, 3),
+            tol,
+            tol,
+            tol,
+            1000,
+            250,
+        )
+        print(project_onto_simplex(np.array([1.3, 0.8])))
+        breakpoint()
         # Check that we are within the bounds of the simplex
         ref_proj = project_onto_simplex(ref_coords[0])
         np.testing.assert_allclose(ref_proj, ref_coords[0])

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.typing as npt
 from scipy.optimize import minimize
 from scifem import closest_point_projection
-from scifem.geometry import project_onto_simplex
+from scifem.geometry import project_onto_simplex, _closest_point_projection
 import ufl
 import basix.ufl
 import pytest
@@ -56,6 +56,7 @@ def scipy_project_point_to_element(
     initial_guess = np.full(mesh.topology.dim, 1 / (mesh.topology.dim + 1), dtype=np.float64)
     tol = np.sqrt(np.finfo(mesh.geometry.x.dtype).eps) if tol is None else tol
     closest_points = np.zeros((target_points.shape[0], 3), dtype=mesh.geometry.x.dtype)
+    ref_points = np.zeros((target_points.shape[0], mesh.topology.dim), dtype=mesh.geometry.x.dtype)
     for i, (coord, target_point) in enumerate(zip(node_coords, target_points)):
         coord = coord.reshape(-1, mesh.geometry.dim)
 
@@ -91,12 +92,14 @@ def scipy_project_point_to_element(
             options={"disp": False, "ftol": tol, "maxiter": 250},
         )
         closest_points[i] = S(res.x)
+        ref_points[i] = res.x
         assert res.success, f"Optimization failed for {cells[i]} and {target_point=}: {res.message}"
-    return closest_points, res.x
+    return closest_points, ref_points
 
 
+@pytest.mark.parametrize("num_threads", [1, 2, 4])
 @pytest.mark.parametrize("order", [1, 2])
-def test_2D_manifold(order):
+def test_2D_manifold(order, num_threads):
     comm = MPI.COMM_SELF
 
     # Curved quadratic triangle in 3D (6 nodes)
@@ -117,63 +120,70 @@ def test_2D_manifold(order):
         cells = cells[:, :3]
     mesh = dolfinx.mesh.create_mesh(comm, cells=cells, x=curved_nodes, e=c_el)
 
-    tol = 1e-7
+    tol_x = 1e-6
     tol_dist = 1e-7
-    theta = np.linspace(0, 4 * np.pi, 250)
+    theta = np.linspace(0, 4 * np.pi, 1_000_000)
     rand = np.random.RandomState(42)
     R = rand.rand(len(theta))
     z = rand.rand(len(theta)) * 0.5  # Add some random z variation
     points = np.vstack([R * np.cos(theta), R * np.sin(theta), z]).T
 
-    for point_to_project in points:
-        import time
+    cells = np.zeros(points.shape[0], dtype=np.int32)
+    import time
 
-        start_scipy = time.perf_counter()
-        (result_scipy, ref_scipy) = scipy_project_point_to_element(
-            mesh, np.array([0], dtype=np.int32), point_to_project, tol=tol
-        )
-        end_scipy = time.perf_counter()
-        start = time.perf_counter()
-        result, ref_coords = closest_point_projection(
-            mesh, np.array([0], dtype=np.int32), point_to_project, tol_x=tol, tol_dist=tol_dist
-        )
-        end = time.perf_counter()
-        import scifem
+    start = time.perf_counter()
+    closest_point, closest_ref = closest_point_projection(
+        mesh,
+        cells,
+        points,
+        tol_x=tol_x,
+        tol_dist=tol_dist,
+        tol_grad=1e-16,
+        max_iter=2000,
+        max_ls_iter=250,
+        num_threads=num_threads,
+    )
+    end = time.perf_counter()
+    print(len(cells))
+    print(
+        f"Projection completed in {end - start:.5e} seconds with num_threads={num_threads} and order={order}."
+    )
+    start_scipy = time.perf_counter()
+    (result_scipy, ref_scipy) = scipy_project_point_to_element(mesh, cells, points, tol=tol_dist)
+    end_scipy = time.perf_counter()
+    print(f"Scipy projection completed in {end_scipy - start_scipy:.5e} seconds.")
 
-        start_cpp = time.perf_counter()
-        closest_point, closest_ref = scifem._scifem.closest_point_projection_float64(
-            mesh._cpp_object,
-            np.array([0], dtype=np.int32),
-            point_to_project.reshape(-1, 3),
-            tol,
-            tol_dist=tol_dist,
-            tol_grad=1e-16,
-            max_iter=2000,
-            max_ls_iter=250,
-            num_threads=1,
+    start_python = time.perf_counter()
+    result, ref_coords = _closest_point_projection(
+        mesh, cells, points, tol_x=tol_x, tol_dist=tol_dist
+    )
+    end_python = time.perf_counter()
+    print(f"Python projection completed in {end_python - start_python:.5e} seconds.")
+
+    for i, point_to_project in enumerate(points):
+        # Check that python and C++ implementations give the same result
+        np.testing.assert_allclose(result[i].flatten(), closest_point[i].flatten(), atol=tol_dist)
+        np.testing.assert_allclose(
+            ref_coords[i].flatten(), closest_ref[i].flatten(), atol=10 * tol_dist
         )
-        end_cpp = time.perf_counter()
-        print(
-            f"Python: {end - start:.6e} seconds, C++: {end_cpp - start_cpp:.6e} seconds,",
-            f"Scipy: {end_scipy - start_scipy:.6e} seconds",
-        )
-        np.testing.assert_allclose(result.flatten(), closest_point.flatten(), atol=tol)
-        np.testing.assert_allclose(ref_coords.flatten(), closest_ref.flatten(), atol=10 * tol)
 
         # Check that we are within the bounds of the simplex
-        ref_proj = project_onto_simplex(ref_coords[0])
-        np.testing.assert_allclose(ref_proj, ref_coords[0])
+        ref_proj = project_onto_simplex(ref_coords[i])
+        np.testing.assert_allclose(ref_proj, ref_coords[i])
 
-        dist_scipy = 0.5 * np.sum(result_scipy - point_to_project) ** 2
-        dist_ours = 0.5 * np.sum(result - point_to_project) ** 2
+        # Check that scipy and our implementation give similar distances,
+        # allowing for some tolerance due to different optimization methods
+        dist_scipy = 0.5 * np.sum(result_scipy[i] - point_to_project) ** 2
+        dist_ours = 0.5 * np.sum(result[i] - point_to_project) ** 2
         if not np.isclose(dist_ours, dist_scipy, atol=tol_dist, rtol=1e-2):
-            assert np.linalg.norm(ref_coords - ref_scipy) < 1e-2
+            assert np.linalg.norm(ref_coords[i] - ref_scipy[i]) < 1e-2
         else:
-            assert np.isclose(dist_ours, dist_scipy, atol=tol, rtol=1e-2)
+            assert np.isclose(dist_ours, dist_scipy, atol=tol_dist, rtol=1e-2)
 
 
+@pytest.mark.parametrize("num_threads", [1, 2, 4])
 @pytest.mark.parametrize("order", [1, 2])
-def test_3D_curved_cell(order):
+def test_3D_curved_cell(order, num_threads):
     comm = MPI.COMM_SELF
 
     curved_nodes_tet = np.array(
@@ -201,52 +211,43 @@ def test_3D_curved_cell(order):
 
     rand = np.random.RandomState(32)
     points = rand.rand(100, 3) - 0.5 * rand.rand(100, 3)
-    tol = 1e-7
+    tol_x = 1e-6
     tol_dist = 1e-7
 
-    for point_to_project in points:
-        import time
-
-        start_scipy = time.perf_counter()
-        (result_scipy, ref_scipy) = scipy_project_point_to_element(
-            mesh, np.array([0], dtype=np.int32), point_to_project, tol=tol
+    cells = np.zeros(points.shape[0], dtype=np.int32)
+    closest_point, closest_ref = closest_point_projection(
+        mesh,
+        cells,
+        points,
+        tol_x=tol_x,
+        tol_dist=tol_dist,
+        tol_grad=1e-16,
+        max_iter=2000,
+        max_ls_iter=250,
+        num_threads=num_threads,
+    )
+    (result_scipy, ref_scipy) = scipy_project_point_to_element(mesh, cells, points, tol=tol_dist)
+    result, ref_coords = closest_point_projection(
+        mesh,
+        cells,
+        points,
+        tol_x=tol_x,
+        tol_dist=tol_dist,
+        tol_grad=1e-16,
+    )
+    for i, point_to_project in enumerate(points):
+        np.testing.assert_allclose(result[i].flatten(), closest_point[i].flatten(), atol=tol_dist)
+        np.testing.assert_allclose(
+            ref_coords[i].flatten(), closest_ref[i].flatten(), atol=10 * tol_x
         )
-        end_scipy = time.perf_counter()
-        start = time.perf_counter()
-        result, ref_coords = closest_point_projection(
-            mesh, np.array([0], dtype=np.int32), point_to_project, tol_x=tol, tol_dist=tol_dist
-        )
-        end = time.perf_counter()
-        import scifem
-
-        start_cpp = time.perf_counter()
-        closest_point, closest_ref = scifem._scifem.closest_point_projection_float64(
-            mesh._cpp_object,
-            np.array([0], dtype=np.int32),
-            point_to_project.reshape(-1, 3),
-            tol,
-            tol_dist=tol_dist,
-            tol_grad=1e-16,
-            max_iter=2000,
-            max_ls_iter=250,
-            num_threads=1,
-        )
-        end_cpp = time.perf_counter()
-        print(
-            f"Python: {end - start:.6e} seconds, C++: {end_cpp - start_cpp:.6e} seconds",
-            f", Scipy: {end_scipy - start_scipy:.6e} seconds",
-        )
-
-        np.testing.assert_allclose(result.flatten(), closest_point.flatten(), atol=tol)
-        np.testing.assert_allclose(ref_coords.flatten(), closest_ref.flatten(), atol=10 * tol)
 
         # Check that we are within the bounds of the simplex
-        ref_proj = project_onto_simplex(ref_coords[0])
-        np.testing.assert_allclose(ref_proj, ref_coords[0])
+        ref_proj = project_onto_simplex(ref_coords[i])
+        np.testing.assert_allclose(ref_proj, ref_coords[i])
 
-        dist_scipy = 0.5 * np.sum(result_scipy - point_to_project) ** 2
-        dist_ours = 0.5 * np.sum(result - point_to_project) ** 2
+        dist_scipy = 0.5 * np.sum(result_scipy[i] - point_to_project) ** 2
+        dist_ours = 0.5 * np.sum(result[i] - point_to_project) ** 2
         if not np.isclose(dist_ours, dist_scipy, atol=tol_dist, rtol=1e-2):
-            assert np.linalg.norm(ref_coords - ref_scipy) < 1e-2
+            assert np.linalg.norm(ref_coords[i] - ref_scipy[i]) < 1e-2
         else:
-            assert np.isclose(dist_ours, dist_scipy, atol=tol, rtol=1e-2)
+            assert np.isclose(dist_ours, dist_scipy, atol=tol_dist, rtol=1e-2)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -122,7 +122,7 @@ def test_2D_manifold(order, num_threads):
 
     tol_x = 1e-6
     tol_dist = 1e-7
-    theta = np.linspace(0, 4 * np.pi, 1_000_000)
+    theta = np.linspace(0, 4 * np.pi, 10_000)
     rand = np.random.RandomState(42)
     R = rand.rand(len(theta))
     z = rand.rand(len(theta)) * 0.5  # Add some random z variation

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -146,21 +146,18 @@ def test_2D_manifold(order):
             np.array([0], dtype=np.int32),
             point_to_project.reshape(-1, 3),
             tol,
-            tol,
-            tol,
-            250,
-            200,
+            tol_dist=tol_dist,
+            tol_grad=1e-10,
+            max_iter=2000,
+            max_ls_iter=250,
         )
         end_cpp = time.perf_counter()
         print(
             f"Python: {end - start:.6e} seconds, C++: {end_cpp - start_cpp:.6e} seconds, Scipy: {end_scipy - start_scipy:.6e} seconds"
         )
         np.testing.assert_allclose(result.flatten(), closest_point.flatten(), atol=tol)
-        np.testing.assert_allclose(ref_coords.flatten(), closest_ref.flatten(), atol=tol)
-        assert False
-        breakpoint()
-        print(project_onto_simplex(np.array([1.3, 0.8])))
-        breakpoint()
+        np.testing.assert_allclose(ref_coords.flatten(), closest_ref.flatten(), atol=10 * tol)
+
         # Check that we are within the bounds of the simplex
         ref_proj = project_onto_simplex(ref_coords[0])
         np.testing.assert_allclose(ref_proj, ref_coords[0])

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -150,6 +150,7 @@ def test_2D_manifold(order):
             tol_grad=1e-16,
             max_iter=2000,
             max_ls_iter=250,
+            num_threads=1
         )
         end_cpp = time.perf_counter()
         print(
@@ -228,6 +229,7 @@ def test_3D_curved_cell(order):
             tol_grad=1e-16,
             max_iter=2000,
             max_ls_iter=250,
+            num_threads=1
         )
         end_cpp = time.perf_counter()
         print(

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,5 +1,3 @@
-from datetime import time
-
 from mpi4py import MPI
 import dolfinx
 import numpy as np

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -153,7 +153,8 @@ def test_2D_manifold(order):
         )
         end_cpp = time.perf_counter()
         print(
-            f"Python: {end - start:.6e} seconds, C++: {end_cpp - start_cpp:.6e} seconds, Scipy: {end_scipy - start_scipy:.6e} seconds"
+            f"Python: {end - start:.6e} seconds, C++: {end_cpp - start_cpp:.6e} seconds,",
+            f"Scipy: {end_scipy - start_scipy:.6e} seconds",
         )
         np.testing.assert_allclose(result.flatten(), closest_point.flatten(), atol=tol)
         np.testing.assert_allclose(ref_coords.flatten(), closest_ref.flatten(), atol=10 * tol)
@@ -230,7 +231,8 @@ def test_3D_curved_cell(order):
         )
         end_cpp = time.perf_counter()
         print(
-            f"Python: {end - start:.6e} seconds, C++: {end_cpp - start_cpp:.6e} seconds, Scipy: {end_scipy - start_scipy:.6e} seconds"
+            f"Python: {end - start:.6e} seconds, C++: {end_cpp - start_cpp:.6e} seconds",
+            f", Scipy: {end_scipy - start_scipy:.6e} seconds",
         )
 
         np.testing.assert_allclose(result.flatten(), closest_point.flatten(), atol=tol)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -125,7 +125,7 @@ def test_2D_manifold(order, num_threads):
 
     tol_x = 5e-6
     tol_dist = 1e-7
-    theta = np.linspace(0, 4 * np.pi, 10_000)
+    theta = np.linspace(0, 4 * np.pi, 3_016)
     rand = np.random.RandomState(42)
     R = rand.rand(len(theta))
     z = rand.rand(len(theta)) * 0.5  # Add some random z variation
@@ -198,7 +198,7 @@ def test_3D_curved_cell(order, num_threads):
     mesh = dolfinx.mesh.create_mesh(comm, cells=cells_tet, x=curved_nodes_tet, e=domain_tet)
 
     rand = np.random.RandomState(32)
-    M = 10_000
+    M = 5_001
     points = rand.rand(M, 3) - 0.5 * rand.rand(M, 3)
     tol_x = 1e-7
     tol_dist = 1e-7

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -147,7 +147,7 @@ def test_2D_manifold(order):
             point_to_project.reshape(-1, 3),
             tol,
             tol_dist=tol_dist,
-            tol_grad=1e-10,
+            tol_grad=1e-16,
             max_iter=2000,
             max_ls_iter=250,
         )
@@ -225,7 +225,7 @@ def test_3D_curved_cell(order):
             point_to_project.reshape(-1, 3),
             tol,
             tol_dist=tol_dist,
-            tol_grad=1e-10,
+            tol_grad=1e-16,
             max_iter=2000,
             max_ls_iter=250,
         )

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -155,9 +155,6 @@ def test_2D_manifold(order):
         print(
             f"Python: {end - start:.6e} seconds, C++: {end_cpp - start_cpp:.6e} seconds, Scipy: {end_scipy - start_scipy:.6e} seconds"
         )
-        # if not np.allclose(result.flatten(), closest_point.flatten(), atol=tol):
-        #     breakpoint()
-
         np.testing.assert_allclose(result.flatten(), closest_point.flatten(), atol=tol)
         np.testing.assert_allclose(ref_coords.flatten(), closest_ref.flatten(), atol=10 * tol)
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -150,7 +150,7 @@ def test_2D_manifold(order):
             tol_grad=1e-16,
             max_iter=2000,
             max_ls_iter=250,
-            num_threads=1
+            num_threads=1,
         )
         end_cpp = time.perf_counter()
         print(
@@ -229,7 +229,7 @@ def test_3D_curved_cell(order):
             tol_grad=1e-16,
             max_iter=2000,
             max_ls_iter=250,
-            num_threads=1
+            num_threads=1,
         )
         end_cpp = time.perf_counter()
         print(

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -214,8 +214,7 @@ def test_3D_curved_cell(order, num_threads):
         max_ls_iter=250,
         num_threads=num_threads,
     )
-    (result_scipy, ref_scipy) = scipy_project_point_to_element(mesh, cells, points, tol=tol_dist)
-    result, ref_coords = closest_point_projection(
+    result, ref_coords = _closest_point_projection(
         mesh,
         cells,
         points,

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -7,6 +7,7 @@ from scifem import closest_point_projection
 from scifem.geometry import project_onto_simplex
 import ufl
 import basix.ufl
+import pytest
 
 
 def scipy_project_point_to_element(
@@ -94,7 +95,8 @@ def scipy_project_point_to_element(
     return closest_points, res.x
 
 
-def test_2D_curved_manifold():
+@pytest.mark.parametrize("order", [1, 2])
+def test_2D_manifold(order):
     comm = MPI.COMM_SELF
 
     # Curved quadratic triangle in 3D (6 nodes)
@@ -109,7 +111,10 @@ def test_2D_curved_manifold():
         ]
     )
     cells = np.array([[0, 1, 2, 3, 4, 5]], dtype=np.int64)  # Single curved triangle element
-    c_el = ufl.Mesh(basix.ufl.element("Lagrange", "triangle", 2, shape=(3,)))
+    c_el = ufl.Mesh(basix.ufl.element("Lagrange", "triangle", order, shape=(3,)))
+    if order == 1:
+        curved_nodes = curved_nodes[:3]  # Use only vertices for linear case
+        cells = cells[:, :3]
     mesh = dolfinx.mesh.create_mesh(comm, cells=cells, x=curved_nodes, e=c_el)
 
     tol = 1e-7
@@ -140,7 +145,8 @@ def test_2D_curved_manifold():
             assert np.isclose(dist_ours, dist_scipy, atol=tol, rtol=1e-2)
 
 
-def test_3D_curved_cell():
+@pytest.mark.parametrize("order", [1, 2])
+def test_3D_curved_cell(order):
     comm = MPI.COMM_SELF
 
     curved_nodes_tet = np.array(
@@ -160,7 +166,10 @@ def test_3D_curved_cell():
     )
     cells_tet = np.array([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]], dtype=np.int64)
 
-    domain_tet = ufl.Mesh(basix.ufl.element("Lagrange", "tetrahedron", 2, shape=(3,)))
+    domain_tet = ufl.Mesh(basix.ufl.element("Lagrange", "tetrahedron", order, shape=(3,)))
+    if order == 1:
+        curved_nodes_tet = curved_nodes_tet[:4]  # Use only vertices for linear case
+        cells_tet = cells_tet[:, :4]
     mesh = dolfinx.mesh.create_mesh(comm, cells=cells_tet, x=curved_nodes_tet, e=domain_tet)
 
     rand = np.random.RandomState(32)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -126,25 +126,39 @@ def test_2D_manifold(order):
     points = np.vstack([R * np.cos(theta), R * np.sin(theta), z]).T
 
     for point_to_project in points:
+        import time
+
+        start_scipy = time.perf_counter()
         (result_scipy, ref_scipy) = scipy_project_point_to_element(
             mesh, np.array([0], dtype=np.int32), point_to_project, tol=tol
         )
-
+        end_scipy = time.perf_counter()
+        start = time.perf_counter()
         result, ref_coords = closest_point_projection(
             mesh, np.array([0], dtype=np.int32), point_to_project, tol_x=tol, tol_dist=tol_dist
         )
+        end = time.perf_counter()
         import scifem
 
-        scifem._scifem.closest_point_projection_float64(
+        start_cpp = time.perf_counter()
+        closest_point, closest_ref = scifem._scifem.closest_point_projection_float64(
             mesh._cpp_object,
             np.array([0], dtype=np.int32),
             point_to_project.reshape(-1, 3),
             tol,
             tol,
             tol,
-            1000,
             250,
+            200,
         )
+        end_cpp = time.perf_counter()
+        print(
+            f"Python: {end - start:.6e} seconds, C++: {end_cpp - start_cpp:.6e} seconds, Scipy: {end_scipy - start_scipy:.6e} seconds"
+        )
+        np.testing.assert_allclose(result.flatten(), closest_point.flatten(), atol=tol)
+        np.testing.assert_allclose(ref_coords.flatten(), closest_ref.flatten(), atol=tol)
+        assert False
+        breakpoint()
         print(project_onto_simplex(np.array([1.3, 0.8])))
         breakpoint()
         # Check that we are within the bounds of the simplex

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -203,13 +203,39 @@ def test_3D_curved_cell(order):
     tol_dist = 1e-7
 
     for point_to_project in points:
-        result_scipy, ref_scipy = scipy_project_point_to_element(
+        import time
+
+        start_scipy = time.perf_counter()
+        (result_scipy, ref_scipy) = scipy_project_point_to_element(
             mesh, np.array([0], dtype=np.int32), point_to_project, tol=tol
         )
-
+        end_scipy = time.perf_counter()
+        start = time.perf_counter()
         result, ref_coords = closest_point_projection(
             mesh, np.array([0], dtype=np.int32), point_to_project, tol_x=tol, tol_dist=tol_dist
         )
+        end = time.perf_counter()
+        import scifem
+
+        start_cpp = time.perf_counter()
+        closest_point, closest_ref = scifem._scifem.closest_point_projection_float64(
+            mesh._cpp_object,
+            np.array([0], dtype=np.int32),
+            point_to_project.reshape(-1, 3),
+            tol,
+            tol_dist=tol_dist,
+            tol_grad=1e-10,
+            max_iter=2000,
+            max_ls_iter=250,
+        )
+        end_cpp = time.perf_counter()
+        print(
+            f"Python: {end - start:.6e} seconds, C++: {end_cpp - start_cpp:.6e} seconds, Scipy: {end_scipy - start_scipy:.6e} seconds"
+        )
+
+        np.testing.assert_allclose(result.flatten(), closest_point.flatten(), atol=tol)
+        np.testing.assert_allclose(ref_coords.flatten(), closest_ref.flatten(), atol=10 * tol)
+
         # Check that we are within the bounds of the simplex
         ref_proj = project_onto_simplex(ref_coords[0])
         np.testing.assert_allclose(ref_proj, ref_coords[0])

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -129,9 +129,7 @@ def test_2D_manifold(order, num_threads):
     points = np.vstack([R * np.cos(theta), R * np.sin(theta), z]).T
 
     cells = np.zeros(points.shape[0], dtype=np.int32)
-    import time
 
-    start = time.perf_counter()
     closest_point, closest_ref = closest_point_projection(
         mesh,
         cells,
@@ -143,22 +141,12 @@ def test_2D_manifold(order, num_threads):
         max_ls_iter=250,
         num_threads=num_threads,
     )
-    end = time.perf_counter()
-    print(len(cells))
-    print(
-        f"Projection completed in {end - start:.5e} seconds with num_threads={num_threads} and order={order}."
-    )
-    start_scipy = time.perf_counter()
-    (result_scipy, ref_scipy) = scipy_project_point_to_element(mesh, cells, points, tol=tol_dist)
-    end_scipy = time.perf_counter()
-    print(f"Scipy projection completed in {end_scipy - start_scipy:.5e} seconds.")
 
-    start_python = time.perf_counter()
+    (result_scipy, ref_scipy) = scipy_project_point_to_element(mesh, cells, points, tol=tol_dist)
+
     result, ref_coords = _closest_point_projection(
         mesh, cells, points, tol_x=tol_x, tol_dist=tol_dist
     )
-    end_python = time.perf_counter()
-    print(f"Python projection completed in {end_python - start_python:.5e} seconds.")
 
     for i, point_to_project in enumerate(points):
         # Check that python and C++ implementations give the same result

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -155,6 +155,9 @@ def test_2D_manifold(order):
         print(
             f"Python: {end - start:.6e} seconds, C++: {end_cpp - start_cpp:.6e} seconds, Scipy: {end_scipy - start_scipy:.6e} seconds"
         )
+        # if not np.allclose(result.flatten(), closest_point.flatten(), atol=tol):
+        #     breakpoint()
+
         np.testing.assert_allclose(result.flatten(), closest_point.flatten(), atol=tol)
         np.testing.assert_allclose(ref_coords.flatten(), closest_ref.flatten(), atol=10 * tol)
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,190 @@
+from datetime import time
+
+from mpi4py import MPI
+import dolfinx
+import numpy as np
+import numpy.typing as npt
+from scipy.optimize import minimize
+from scifem import closest_point_projection
+from scifem.geometry import project_onto_simplex
+import ufl
+import basix.ufl
+
+
+def scipy_project_point_to_element(
+    mesh: dolfinx.mesh.Mesh,
+    cells: npt.NDArray[np.int64],
+    target_points: npt.NDArray[np.float64 | np.float32],
+    method=None,
+    tol: float | None = None,
+):
+    """
+    Projects a 3D point onto a cell in a potentially higher order mesh.
+
+    Args:
+        mesh: {py:class}`dolfinx.mesh.Mesh`, the mesh containing the cell.
+        cells: {py:class}`numpy.ndarray`, the indices of the cells to project onto.
+        target_point: (3,) numpy array, the 3D point to project.
+        method: str, the optimization method to use.
+        tol: float, the tolerance for the optimizer.
+
+    Returns:
+        dict: A dictionary containing the reference coordinates, closest 3D point, and distance.
+    """
+
+    # Extract scalar element of mesh
+    element = mesh.ufl_domain().ufl_coordinate_element().sub_elements[0]
+
+    # Get the coordinates of the nodes for the specified cell
+    node_coords = mesh.geometry.x[mesh.geometry.dofmap[cells]][:, :, : mesh.geometry.dim]
+    target_points = target_points.reshape(-1, 3)
+    # cmap = mesh.geometry.cmap
+
+    # Constraints and Bounds
+    cell_type = mesh.topology.cell_type
+    if (
+        cell_type == dolfinx.mesh.CellType.triangle
+        or cell_type == dolfinx.mesh.CellType.tetrahedron
+    ):
+        method = method or "SLSQP"
+        constraint = {"type": "ineq", "fun": lambda x: 1.0 - np.sum(x)}
+    else:
+        method = method or "L-BFGS-B"
+        constraint = {}
+    bounds = [(0.0, 1.0) for _ in range(mesh.topology.dim)]
+
+    # Set initial guess and tolerance for solver
+    initial_guess = np.full(mesh.topology.dim, 1 / (mesh.topology.dim + 1), dtype=np.float64)
+    tol = np.sqrt(np.finfo(mesh.geometry.x.dtype).eps) if tol is None else tol
+    closest_points = np.zeros((target_points.shape[0], 3), dtype=mesh.geometry.x.dtype)
+    for i, (coord, target_point) in enumerate(zip(node_coords, target_points)):
+        coord = coord.reshape(-1, mesh.geometry.dim)
+
+        def S(x_ref):
+            N_vals = element.tabulate(0, x_ref.reshape(1, mesh.topology.dim))[0, 0, :]
+            return np.dot(N_vals, coord)
+
+        def dSdx_ref(x_ref):
+            """Evaluate jacobian (tangent vectors) at the given reference coordinates."""
+            dN = element.tabulate(1, x_ref.reshape(1, mesh.topology.dim))[
+                1 : mesh.topology.dim + 1, 0, :
+            ]
+            return np.dot(dN, coord)
+
+        def objective(x_ref):
+            surface_point = S(x_ref)
+            diff = surface_point - target_point
+            return 0.5 * np.linalg.norm(diff) ** 2
+
+        def objective_grad(x_ref):
+            diff = S(x_ref) - target_point
+            tangents = dSdx_ref(x_ref)
+            return np.dot(tangents, diff)
+
+        res = minimize(
+            objective,
+            initial_guess,
+            method=method,
+            jac=objective_grad,
+            bounds=bounds,
+            constraints=constraint,
+            tol=tol,
+            options={"disp": False, "ftol": tol, "maxiter": 250},
+        )
+        closest_points[i] = S(res.x)
+        assert res.success, f"Optimization failed for {cells[i]} and {target_point=}: {res.message}"
+    return closest_points, res.x
+
+
+def test_2D_curved_manifold():
+    comm = MPI.COMM_SELF
+
+    # Curved quadratic triangle in 3D (6 nodes)
+    curved_nodes = np.array(
+        [
+            [0.0, 0.0, 0.0],  # Node 0: Vertex
+            [1.0, 0.0, 0.0],  # Node 1: Vertex
+            [0.0, 1.0, 0.0],  # Node 2: Vertex
+            [0.6, 0.6, 0.0],  # Node 4: Edge 1-2
+            [0.1, 0.5, 0.2],  # Node 5: Edge 2-0 (curved upward in Z)
+            [0.5, 0.1, 0.2],  # Node 3: Edge 0-1 (curved upward in Z)
+        ]
+    )
+    cells = np.array([[0, 1, 2, 3, 4, 5]], dtype=np.int64)  # Single curved triangle element
+    c_el = ufl.Mesh(basix.ufl.element("Lagrange", "triangle", 2, shape=(3,)))
+    mesh = dolfinx.mesh.create_mesh(comm, cells=cells, x=curved_nodes, e=c_el)
+
+    tol = 1e-7
+    tol_dist = 1e-7
+    theta = np.linspace(0, 4 * np.pi, 250)
+    rand = np.random.RandomState(42)
+    R = rand.rand(len(theta))
+    z = rand.rand(len(theta)) * 0.5  # Add some random z variation
+    points = np.vstack([R * np.cos(theta), R * np.sin(theta), z]).T
+
+    for point_to_project in points:
+        (result_scipy, ref_scipy) = scipy_project_point_to_element(
+            mesh, np.array([0], dtype=np.int32), point_to_project, tol=tol
+        )
+
+        result, ref_coords = closest_point_projection(
+            mesh, np.array([0], dtype=np.int32), point_to_project, tol_x=tol, tol_dist=tol_dist
+        )
+        # Check that we are within the bounds of the simplex
+        ref_proj = project_onto_simplex(ref_coords[0])
+        np.testing.assert_allclose(ref_proj, ref_coords[0])
+
+        dist_scipy = 0.5 * np.sum(result_scipy - point_to_project) ** 2
+        dist_ours = 0.5 * np.sum(result - point_to_project) ** 2
+        if not np.isclose(dist_ours, dist_scipy, atol=tol_dist, rtol=1e-2):
+            assert np.linalg.norm(ref_coords - ref_scipy) < 1e-2
+        else:
+            assert np.isclose(dist_ours, dist_scipy, atol=tol, rtol=1e-2)
+
+
+def test_3D_curved_cell():
+    comm = MPI.COMM_SELF
+
+    curved_nodes_tet = np.array(
+        [
+            [0.0, 0.0, 0.0],  # 0: Vertex
+            [1.0, 0.0, 0.0],  # 1: Vertex
+            [0.0, 1.0, 0.0],  # 2: Vertex
+            [0.0, 0.0, 1.0],  # 3: Vertex
+            [0.0, 0.5, 0.5],  # 4: Edge 2-3
+            [0.5, 0.0, 0.5],  # 5: Edge 1-3
+            [0.5, 0.5, 0.0],  # 6: Edge 1-2
+            [0.0, 0.0, 0.5],  # 9: Edge 0-3
+            [0.0, 0.5, 0.2],  # 8: Edge 0-2 (Curved)
+            [0.5, 0.0, 0.2],  # 7: Edge 0-1 (Curved)
+        ],
+        dtype=np.float64,
+    )
+    cells_tet = np.array([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]], dtype=np.int64)
+
+    domain_tet = ufl.Mesh(basix.ufl.element("Lagrange", "tetrahedron", 2, shape=(3,)))
+    mesh = dolfinx.mesh.create_mesh(comm, cells=cells_tet, x=curved_nodes_tet, e=domain_tet)
+
+    rand = np.random.RandomState(32)
+    points = rand.rand(100, 3) - 0.5 * rand.rand(100, 3)
+    tol = 1e-7
+    tol_dist = 1e-7
+
+    for point_to_project in points:
+        result_scipy, ref_scipy = scipy_project_point_to_element(
+            mesh, np.array([0], dtype=np.int32), point_to_project, tol=tol
+        )
+
+        result, ref_coords = closest_point_projection(
+            mesh, np.array([0], dtype=np.int32), point_to_project, tol_x=tol, tol_dist=tol_dist
+        )
+        # Check that we are within the bounds of the simplex
+        ref_proj = project_onto_simplex(ref_coords[0])
+        np.testing.assert_allclose(ref_proj, ref_coords[0])
+
+        dist_scipy = 0.5 * np.sum(result_scipy - point_to_project) ** 2
+        dist_ours = 0.5 * np.sum(result - point_to_project) ** 2
+        if not np.isclose(dist_ours, dist_scipy, atol=tol_dist, rtol=1e-2):
+            assert np.linalg.norm(ref_coords - ref_scipy) < 1e-2
+        else:
+            assert np.isclose(dist_ours, dist_scipy, atol=tol, rtol=1e-2)


### PR DESCRIPTION
After discussing with @thomas-surowiec we decided that the fastest approach is probably the projected gradient method.

Using the algorithms from the following papers:
**Simplex projection**:
- Algorithm 1 in Laurent Condat. Fast Projection onto the Simplex and the l1 Ball. (2016) DOI: [10.1007/s10107-015-0946-6](https://doi.org/10.1007/s10107-015-0946-6), which is from:
  - Held, M., Wolfe, P., Crowder, H.: Validation of subgradient optimization (1974) DOI: [10.1007/BF01580223](https://doi.org/10.1007/BF01580223)
  
Using the Goldstein-Levitin-Polyak gradient projection method, with linesearch method from:
- Dimitri P. Bertsekas, "On the Goldstein-Levitin-Polyak gradient projection method" (1976) DOI: [10.1109/TAC.1976.1101194](https://doi.org/10.1109/TAC.1976.1101194)

Implements reference solver using scipy, a python implementation for debugging, and a highly optimized C++ version that allows for threading.