### PR TITLE
Support ufl expressions and submesh quantities in interpolate_to_surface_submesh

### DIFF
--- a/src/scifem/interpolation.py
+++ b/src/scifem/interpolation.py
@@ -402,6 +402,6 @@ def interpolate_to_surface_submesh(
         interpolate_func = u_surface._cpp_object.interpolate_f
     else:
         interpolate_func = u_surface._cpp_object.interpolate
-    breakpoint()
+
     interpolate_func(shaped_data, submesh_facets)
     u_surface.x.scatter_forward()

--- a/src/scifem/interpolation.py
+++ b/src/scifem/interpolation.py
@@ -333,6 +333,7 @@ def interpolate_to_surface_submesh(
     u_surface: dolfinx.fem.Function,
     submesh_facets: npt.NDArray[np.int32],
     integration_entities: npt.NDArray[np.int32],
+    entity_maps: list[dolfinx.mesh.EntityMap] | None = None,
 ):
     """
     Interpolate a function `u_volume` into the function `u_surface`.
@@ -350,24 +351,29 @@ def interpolate_to_surface_submesh(
     """
     if Version(dolfinx.__version__) < Version("0.10.0"):
         raise RuntimeError("interpolate_to_submesh requires dolfinx version 0.10.0 or higher")
-    V_vol = u_volume.function_space
-    mesh = V_vol.mesh
+    ufl_domains = ufl.domain.extract_domains(u_volume)
+    max_tdim_pos = np.argmax([domain.ufl_cargo().topology.dim for domain in ufl_domains])
+    mesh = dolfinx.mesh.Mesh(ufl_domains[max_tdim_pos].ufl_cargo(), ufl_domains[max_tdim_pos])
+
     V_surf = u_surface.function_space
     submesh = V_surf.mesh
     ip = V_surf.element.interpolation_points
 
-    expr = dolfinx.fem.Expression(u_volume, ip)
-
+    try:
+        expr = dolfinx.fem.Expression(u_volume, ip, entity_maps=entity_maps)
+    except TypeError:
+        expr = dolfinx.fem.Expression(u_volume, ip)
     mesh.topology.create_connectivity(mesh.topology.dim, submesh.topology.dim)
     mesh.topology.create_connectivity(submesh.topology.dim, mesh.topology.dim)
 
     data = expr.eval(mesh, integration_entities)
-
     submesh.topology.create_entity_permutations()
     mesh.topology.create_entity_permutations()
     ft = V_surf.element.basix_element.cell_type
 
     if Version(dolfinx.__version__) < Version("0.11.0.dev0"):
+        V_vol = u_volume.function_space
+        mesh = V_vol.mesh
         # Before the introduction of https://github.com/FEniCS/dolfinx/pull/4140
         # one needed to permute the data according to the facet permutations.
         cell_info = mesh.topology.get_cell_permutation_info()
@@ -396,5 +402,6 @@ def interpolate_to_surface_submesh(
         interpolate_func = u_surface._cpp_object.interpolate_f
     else:
         interpolate_func = u_surface._cpp_object.interpolate
+    breakpoint()
     interpolate_func(shaped_data, submesh_facets)
     u_surface.x.scatter_forward()


### PR DESCRIPTION
Following the updates in DOLFINx (https://github.com/FEniCS/dolfinx/pull/4140) we can now evaluate expressions (not backwards compatible) in interpolate_to_surface_submesh.
Additional support for sub-meshes through entity maps.

```python
from mpi4py import MPI
import dolfinx
import ufl
import numpy as np
import scifem


def cell_locator(x):
    return x[0] > 0.1 - 1e-10


mesh = dolfinx.mesh.create_rectangle(MPI.COMM_WORLD, [[-0.2, -0.2], [1.1, 1.1]], [11, 13])

degree = 3
Vh = dolfinx.fem.functionspace(mesh, ("Lagrange", degree, (mesh.geometry.dim,)))
uh = dolfinx.fem.Function(Vh)
uh.interpolate(
    lambda x: (1.3*(x[0]-0.823)**2-(x[1]-0.9012)**2, (x[0]-0.475)**3 - 0.2*(x[1]-0.852)**2),
    cells0=dolfinx.mesh.locate_entities(mesh, mesh.topology.dim, cell_locator),
)

tdim = mesh.topology.dim
fdim = tdim - 1
mesh.topology.create_connectivity(fdim, tdim)
exterior_facets = dolfinx.mesh.exterior_facet_indices(mesh.topology)

nh = ufl.FacetNormal(mesh)


# Define submesh of the facets you would like to compute the maximum over
facet_submesh, entity_map = dolfinx.mesh.create_submesh(mesh, fdim, exterior_facets)[0:2]
num_submesh_cells = facet_submesh.topology.index_map(fdim).size_local
parent_facets = entity_map.sub_topology_to_topology(
    np.arange(num_submesh_cells, dtype=np.int64), inverse=False
)
exterior_facet_as_integration_entities = dolfinx.fem.compute_integration_domains(
    dolfinx.fem.IntegralType.exterior_facet, mesh.topology, parent_facets
).reshape(-1, 2)


expr = ufl.as_vector((uh[1] * nh[0], uh[0] * nh[1]))

Qh = dolfinx.fem.functionspace(facet_submesh, ("DG", 2, (mesh.geometry.dim,)))
facet_expr = dolfinx.fem.Function(Qh)
scifem.interpolation.interpolate_to_surface_submesh(expr, facet_expr, np.arange(len(parent_facets), dtype=np.int32), exterior_facet_as_integration_entities)

with dolfinx.io.VTXWriter(facet_submesh.comm, "facet_expr.bp", [facet_expr]) as writer:
    writer.write(0.0)

with dolfinx.io.VTXWriter(facet_submesh.comm, "uh.bp", [uh]) as writer:
    writer.write(0.0)


# Use scifem to compute maximum


max_expression = ufl.dot(facet_expr, facet_expr)

value, point_of_extrema = scifem.compute_extrema(max_expression, kind=max)
print(value, point_of_extrema)
```
yielding
```bash
1.4704992620052726 [ 0.823 -0.2  ]
```
<img width="2272" height="2218" alt="image" src="https://github.com/user-attachments/assets/7fd38ea9-11ba-4acb-840b-fdccd93c3ac5" />
